### PR TITLE
Updated everything to use `ClientFirestoreCollectionService`

### DIFF
--- a/packages/extension/src/components/App.ext.tsx
+++ b/packages/extension/src/components/App.ext.tsx
@@ -33,7 +33,7 @@ export const App: React.FC = () => {
       return;
     }
 
-    const addFeedItemResult = await feedItemsService.addFeedItem({
+    const addFeedItemResult = await feedItemsService.createFeedItem({
       url: tabUrl,
       source: FEED_ITEM_APP_SOURCE,
     });

--- a/packages/pwa/src/components/devToolbar/RegisterFeedItemImporterDevTool.tsx
+++ b/packages/pwa/src/components/devToolbar/RegisterFeedItemImporterDevTool.tsx
@@ -34,7 +34,7 @@ const FeedItemImporter: React.FC = () => {
         return;
       }
 
-      const addFeedItemResult = await feedItemsService.addFeedItem({
+      const addFeedItemResult = await feedItemsService.createFeedItem({
         url: trimmedUrl,
         source: FEED_ITEM_APP_SOURCE,
       });

--- a/packages/shared/src/services/eventLog.shared.ts
+++ b/packages/shared/src/services/eventLog.shared.ts
@@ -1,156 +1,15 @@
-import type {CollectionReference, FieldValue} from 'firebase/firestore';
-import {
-  deleteDoc,
-  doc,
-  limit as firestoreLimit,
-  getDoc,
-  onSnapshot,
-  orderBy,
-  query,
-  setDoc,
-  updateDoc,
-  where,
-} from 'firebase/firestore';
-
-import {logger} from '@shared/services/logger.shared';
-
-import {asyncTry, prefixError} from '@shared/lib/errorUtils.shared';
+import type {FieldValue} from 'firebase/firestore';
 
 import type {
-  EventId,
-  EventLogItem,
   FeedItemActionEventLogItem,
   UserFeedSubscriptionEventLogItem,
 } from '@shared/types/eventLog.types';
 import {EventType, makeEventId} from '@shared/types/eventLog.types';
 import type {FeedItemActionType, FeedItemId} from '@shared/types/feedItems.types';
-import type {AsyncResult, Result} from '@shared/types/result.types';
+import type {Result} from '@shared/types/result.types';
 import {makeSuccessResult} from '@shared/types/result.types';
 import type {UserId} from '@shared/types/user.types';
 import type {UserFeedSubscriptionId} from '@shared/types/userFeedSubscriptions.types';
-import type {Consumer, Unsubscribe} from '@shared/types/utils.types';
-
-export class SharedEventLogService {
-  private readonly eventLogDbRef: CollectionReference;
-  private readonly userId: UserId;
-
-  constructor(args: {readonly eventLogDbRef: CollectionReference; readonly userId: UserId}) {
-    this.eventLogDbRef = args.eventLogDbRef;
-    this.userId = args.userId;
-  }
-
-  public async fetchEventLogItem(eventId: EventId): AsyncResult<EventLogItem | null> {
-    return await asyncTry(async () => {
-      // TODO: Use Firebase helper.
-      const snapshot = await getDoc(doc(this.eventLogDbRef, eventId));
-      if (!snapshot.exists()) return null;
-      return {...snapshot.data(), eventId: snapshot.id} as EventLogItem;
-    });
-  }
-
-  public watchEventLogItem(
-    eventId: EventId,
-    successCallback: Consumer<EventLogItem | null>, // null means event log item does not exist.
-    errorCallback: Consumer<Error>
-  ): Unsubscribe {
-    const unsubscribe = onSnapshot(
-      doc(this.eventLogDbRef, eventId),
-      (snapshot) => {
-        if (snapshot.exists()) {
-          successCallback({...snapshot.data(), eventId: snapshot.id} as EventLogItem);
-        } else {
-          successCallback(null);
-        }
-      },
-      errorCallback
-    );
-    return () => unsubscribe();
-  }
-
-  public watchEventLog(args: {
-    readonly successCallback: Consumer<EventLogItem[]>;
-    readonly errorCallback: Consumer<Error>;
-    readonly limit?: number;
-  }): Unsubscribe {
-    const {successCallback, errorCallback, limit} = args;
-
-    const itemsQuery = query(
-      this.eventLogDbRef,
-      where('userId', '==', this.userId),
-      ...(limit ? [firestoreLimit(limit)] : []),
-      orderBy('createdTime', 'desc')
-    );
-
-    const unsubscribe = onSnapshot(
-      itemsQuery,
-      (snapshot) => {
-        const items = snapshot.docs.map((doc) => doc.data() as EventLogItem);
-        successCallback(items);
-      },
-      errorCallback
-    );
-    return () => unsubscribe();
-  }
-
-  public async logEvent(eventLogItemResult: Result<EventLogItem>): AsyncResult<EventId | null> {
-    if (!eventLogItemResult.success) {
-      return eventLogItemResult;
-    }
-
-    const eventLogItem = eventLogItemResult.value;
-    const eventLogItemDoc = doc(this.eventLogDbRef, eventLogItem.eventId);
-
-    const addEventLogItemResult = await asyncTry(async () => setDoc(eventLogItemDoc, eventLogItem));
-
-    if (!addEventLogItemResult.success) {
-      logger.error(prefixError(addEventLogItemResult.error, 'Failed to log event'), {eventLogItem});
-      return addEventLogItemResult;
-    }
-
-    return makeSuccessResult(eventLogItem.eventId);
-  }
-
-  public async logFeedItemActionEvent(args: {
-    readonly feedItemId: FeedItemId;
-    readonly feedItemActionType: FeedItemActionType;
-    readonly createdTime: FieldValue;
-    readonly lastUpdatedTime: FieldValue;
-  }): AsyncResult<EventId | null> {
-    const eventLogItemResult = makeFeedItemActionEventLogItem({
-      userId: this.userId,
-      feedItemId: args.feedItemId,
-      feedItemActionType: args.feedItemActionType,
-      createdTime: args.createdTime,
-      lastUpdatedTime: args.lastUpdatedTime,
-    });
-    return this.logEvent(eventLogItemResult);
-  }
-
-  public async logUserFeedSubscriptionEvent(args: {
-    readonly userFeedSubscriptionId: UserFeedSubscriptionId;
-    readonly createdTime: FieldValue;
-    readonly lastUpdatedTime: FieldValue;
-  }): AsyncResult<EventId | null> {
-    const eventLogItemResult = makeUserFeedSubscriptionEventLogItem({
-      userId: this.userId,
-      userFeedSubscriptionId: args.userFeedSubscriptionId,
-      createdTime: args.createdTime,
-      lastUpdatedTime: args.lastUpdatedTime,
-    });
-    return this.logEvent(eventLogItemResult);
-  }
-
-  public async updateEventLogItem(
-    eventId: EventId,
-    item: Partial<EventLogItem>
-  ): AsyncResult<void> {
-    return await asyncTry(async () => updateDoc(doc(this.eventLogDbRef, eventId), item));
-  }
-
-  public async deleteEventLogItem(eventId: EventId): AsyncResult<void> {
-    return await asyncTry(async () => deleteDoc(doc(this.eventLogDbRef, eventId)));
-  }
-}
 
 export function makeFeedItemActionEventLogItem(args: {
   readonly userId: UserId;

--- a/packages/shared/src/types/importQueue.types.ts
+++ b/packages/shared/src/types/importQueue.types.ts
@@ -8,7 +8,7 @@ import type {Result} from '@shared/types/result.types';
 import {makeSuccessResult} from '@shared/types/result.types';
 import {UserIdSchema} from '@shared/types/user.types';
 import type {UserId} from '@shared/types/user.types';
-import type {BaseStoreItem, Timestamp} from '@shared/types/utils.types';
+import type {BaseStoreItem} from '@shared/types/utils.types';
 
 /**
  * Strongly-typed type for an {@link ImportQueueItem}'s unique identifier. Prefer this over plain
@@ -74,19 +74,13 @@ export const ImportQueueItemSchema = z.object({
 /**
  * Creates a new {@link ImportQueueItem}.
  */
-export function makeImportQueueItem(args: {
-  readonly feedItemId: FeedItemId;
-  readonly userId: UserId;
-  readonly url: string;
-  readonly createdTime: Timestamp;
-  readonly lastUpdatedTime: Timestamp;
-}): Result<ImportQueueItem> {
+export function makeImportQueueItem(
+  args: Omit<ImportQueueItem, 'importQueueItemId' | 'status'>
+): Result<ImportQueueItem> {
   const {feedItemId, userId, url, createdTime, lastUpdatedTime} = args;
 
-  const importQueueItemId = makeImportQueueItemId();
-
   return makeSuccessResult({
-    importQueueItemId,
+    importQueueItemId: makeImportQueueItemId(),
     feedItemId,
     userId,
     url,

--- a/packages/sharedClient/src/services/feedItems.client.ts
+++ b/packages/sharedClient/src/services/feedItems.client.ts
@@ -1,16 +1,4 @@
-import {
-  collection,
-  deleteDoc,
-  doc,
-  getDoc,
-  onSnapshot,
-  query,
-  serverTimestamp,
-  setDoc,
-  updateDoc,
-  where,
-} from 'firebase/firestore';
-import type {CollectionReference} from 'firebase/firestore';
+import {collection, serverTimestamp, where} from 'firebase/firestore';
 import type {StorageReference} from 'firebase/storage';
 import {getDownloadURL, ref as storageRef} from 'firebase/storage';
 import {useEffect, useMemo, useState} from 'react';
@@ -18,11 +6,10 @@ import {useEffect, useMemo, useState} from 'react';
 import {
   FEED_ITEMS_DB_COLLECTION,
   FEED_ITEMS_STORAGE_COLLECTION,
-  IMPORT_QUEUE_DB_COLLECTION,
 } from '@shared/lib/constants.shared';
 import {
   asyncTry,
-  asyncTryAllPromises,
+  asyncTryAll,
   prefixErrorResult,
   prefixResultIfError,
 } from '@shared/lib/errorUtils.shared';
@@ -30,6 +17,8 @@ import {SharedFeedItemHelpers} from '@shared/lib/feedItems.shared';
 import {requestGet} from '@shared/lib/requests.shared';
 import {isValidUrl} from '@shared/lib/urls.shared';
 import {Views} from '@shared/lib/views.shared';
+
+import {parseFeedItem, parseFeedItemId} from '@shared/parsers/feedItems.parser';
 
 import {
   FeedItemType,
@@ -45,24 +34,33 @@ import type {AuthStateChangedUnsubscribe, UserId} from '@shared/types/user.types
 import type {Consumer} from '@shared/types/utils.types';
 
 import {firebaseService} from '@sharedClient/services/firebase.client';
+import {ClientFirestoreCollectionService} from '@sharedClient/services/firestore.client';
+import {useImportQueueService} from '@sharedClient/services/importQueue.client';
+import type {ClientImportQueueService} from '@sharedClient/services/importQueue.client';
 
 import {useLoggedInUser} from '@sharedClient/hooks/auth.hooks';
 
 const feedItemsDbRef = collection(firebaseService.firestore, FEED_ITEMS_DB_COLLECTION);
-const importQueueDbRef = collection(firebaseService.firestore, IMPORT_QUEUE_DB_COLLECTION);
 const feedItemsStorageRef = storageRef(firebaseService.storage, FEED_ITEMS_STORAGE_COLLECTION);
 
 export function useFeedItemsService(): ClientFeedItemsService {
   const loggedInUser = useLoggedInUser();
+  const importQueueService = useImportQueueService();
 
   const feedItemsService = useMemo(() => {
+    const feedItemsCollectionService = new ClientFirestoreCollectionService({
+      collectionRef: feedItemsDbRef,
+      parseId: parseFeedItemId,
+      parseData: parseFeedItem,
+    });
+
     return new ClientFeedItemsService({
-      feedItemsDbRef,
-      importQueueDbRef,
+      feedItemsCollectionService,
+      importQueueService,
       feedItemsStorageRef,
       userId: loggedInUser.userId,
     });
-  }, [loggedInUser]);
+  }, [loggedInUser.userId, importQueueService]);
 
   return feedItemsService;
 }
@@ -157,31 +155,28 @@ export function useFeedItemMarkdown(
   return state;
 }
 
+type FeedItemsCollectionService = ClientFirestoreCollectionService<FeedItemId, FeedItem>;
+
 export class ClientFeedItemsService {
-  private readonly feedItemsDbRef: CollectionReference;
-  private readonly importQueueDbRef: CollectionReference;
+  private readonly feedItemsCollectionService: FeedItemsCollectionService;
+  private readonly importQueueService: ClientImportQueueService;
   private readonly feedItemsStorageRef: StorageReference;
   private readonly userId: UserId;
 
   constructor(args: {
-    readonly feedItemsDbRef: CollectionReference;
-    readonly importQueueDbRef: CollectionReference;
+    readonly feedItemsCollectionService: FeedItemsCollectionService;
+    readonly importQueueService: ClientImportQueueService;
     readonly feedItemsStorageRef: StorageReference;
     readonly userId: UserId;
   }) {
-    this.feedItemsDbRef = args.feedItemsDbRef;
-    this.importQueueDbRef = args.importQueueDbRef;
+    this.feedItemsCollectionService = args.feedItemsCollectionService;
+    this.importQueueService = args.importQueueService;
     this.feedItemsStorageRef = args.feedItemsStorageRef;
     this.userId = args.userId;
   }
 
-  public async getFeedItem(feedItemId: FeedItemId): AsyncResult<FeedItem | null> {
-    return await asyncTry(async () => {
-      // TODO: Use Firebase helper.
-      const snapshot = await getDoc(doc(this.feedItemsDbRef, feedItemId));
-      if (!snapshot.exists()) return null;
-      return {...snapshot.data(), feedItemId: snapshot.id} as FeedItem;
-    });
+  public async fetchById(feedItemId: FeedItemId): AsyncResult<FeedItem | null> {
+    return this.feedItemsCollectionService.fetchById(feedItemId);
   }
 
   public watchFeedItem(
@@ -189,15 +184,9 @@ export class ClientFeedItemsService {
     successCallback: Consumer<FeedItem | null>, // null means feed item does not exist.
     errorCallback: Consumer<Error>
   ): AuthStateChangedUnsubscribe {
-    const unsubscribe = onSnapshot(
-      doc(this.feedItemsDbRef, feedItemId),
-      (snapshot) => {
-        if (snapshot.exists()) {
-          successCallback({...snapshot.data(), feedItemId: snapshot.id} as FeedItem);
-        } else {
-          successCallback(null);
-        }
-      },
+    const unsubscribe = this.feedItemsCollectionService.watchDoc(
+      feedItemId,
+      successCallback,
       errorCallback
     );
     return () => unsubscribe();
@@ -218,25 +207,17 @@ export class ClientFeedItemsService {
         where(filter.field, fromFilterOperator(filter.op), filter.value)
       ),
     ];
-    const itemsQuery = query(
-      this.feedItemsDbRef,
-      ...whereClauses
-      // TODO: Add order by condition.
-      // orderBy(viewConfig.sort.field, fromSortDirection(viewConfig.sort.direction))
-    );
+    const itemsQuery = this.feedItemsCollectionService.query(whereClauses);
 
-    const unsubscribe = onSnapshot(
+    const unsubscribe = this.feedItemsCollectionService.watchDocs(
       itemsQuery,
-      (snapshot) => {
-        const feedItems = snapshot.docs.map((doc) => doc.data() as FeedItem);
-        successCallback(feedItems);
-      },
+      successCallback,
       errorCallback
     );
     return () => unsubscribe();
   }
 
-  public async addFeedItem(args: {
+  public async createFeedItem(args: {
     readonly url: string;
     readonly source: FeedItemSource;
   }): AsyncResult<FeedItemId | null> {
@@ -269,12 +250,15 @@ export class ClientFeedItemsService {
       lastUpdatedTime: serverTimestamp(),
     });
     if (!makeImportQueueItemResult.success) return makeImportQueueItemResult;
-    const importQueueItem = makeImportQueueItemResult.value;
 
     // TODO: Do these in a transaction.
-    const addFeedItemResult = await asyncTryAllPromises([
-      setDoc(doc(this.feedItemsDbRef, feedItem.feedItemId), feedItem),
-      setDoc(doc(this.importQueueDbRef, importQueueItem.importQueueItemId), importQueueItem),
+    const addFeedItemResult = await asyncTryAll([
+      this.feedItemsCollectionService.setDoc(feedItem.feedItemId, feedItem),
+      this.importQueueService.create({
+        feedItemId: feedItem.feedItemId,
+        userId: this.userId,
+        url: trimmedUrl,
+      }),
     ]);
 
     const addFeedItemResultError = addFeedItemResult.success
@@ -288,7 +272,7 @@ export class ClientFeedItemsService {
   }
 
   public async updateFeedItem(feedItemId: FeedItemId, item: Partial<FeedItem>): AsyncResult<void> {
-    return await asyncTry(async () => updateDoc(doc(this.feedItemsDbRef, feedItemId), item));
+    return this.feedItemsCollectionService.updateDoc(feedItemId, item);
   }
 
   // public async updateFeedItem(feedItemId: FeedItemId, item: Partial<FeedItem>): AsyncResult<void> {
@@ -298,7 +282,7 @@ export class ClientFeedItemsService {
   // }
 
   public async deleteFeedItem(feedItemId: FeedItemId): AsyncResult<void> {
-    return await asyncTry(async () => deleteDoc(doc(this.feedItemsDbRef, feedItemId)));
+    return this.feedItemsCollectionService.deleteDoc(feedItemId);
   }
 
   public async getFeedItemMarkdown(feedItemId: FeedItemId): AsyncResult<string> {

--- a/packages/sharedServer/src/services/eventLog.server.ts
+++ b/packages/sharedServer/src/services/eventLog.server.ts
@@ -1,0 +1,67 @@
+import {logger} from '@shared/services/logger.shared';
+
+import {EVENT_LOG_DB_COLLECTION} from '@shared/lib/constants.shared';
+import {prefixError} from '@shared/lib/errorUtils.shared';
+
+import {parseEventId, parseEventLogItem} from '@shared/parsers/eventLog.parser';
+
+import type {EventId, EventLogItem} from '@shared/types/eventLog.types';
+import {makeSuccessResult, type AsyncResult, type Result} from '@shared/types/result.types';
+
+import {firebaseService} from '@sharedServer/services/firebase.server';
+
+import {ServerFirestoreCollectionService} from './firestore.server';
+
+type ServerEventLogCollectionService = ServerFirestoreCollectionService<EventId, EventLogItem>;
+
+export class ServerEventLogService {
+  private readonly eventLogCollectionService: ServerEventLogCollectionService;
+
+  constructor(args: {readonly eventLogCollectionService: ServerEventLogCollectionService}) {
+    this.eventLogCollectionService = args.eventLogCollectionService;
+  }
+
+  public async fetchById(eventId: EventId): AsyncResult<EventLogItem | null> {
+    return this.eventLogCollectionService.fetchById(eventId);
+  }
+
+  public async logEvent(eventLogItemResult: Result<EventLogItem>): AsyncResult<EventId | null> {
+    if (!eventLogItemResult.success) {
+      return eventLogItemResult;
+    }
+
+    const eventLogItem = eventLogItemResult.value;
+    const createResult = await this.eventLogCollectionService.setDoc(
+      eventLogItem.eventId,
+      eventLogItem
+    );
+
+    if (!createResult.success) {
+      logger.error(prefixError(createResult.error, 'Failed to log event'), {eventLogItem});
+      return createResult;
+    }
+
+    return makeSuccessResult(createResult.value.eventId);
+  }
+
+  public async updateEventLogItem(
+    eventId: EventId,
+    item: Partial<EventLogItem>
+  ): AsyncResult<void> {
+    return this.eventLogCollectionService.updateDoc(eventId, item);
+  }
+
+  public async deleteEventLogItem(eventId: EventId): AsyncResult<void> {
+    return this.eventLogCollectionService.deleteDoc(eventId);
+  }
+}
+
+const eventLogDbRef = firebaseService.firestore.collection(EVENT_LOG_DB_COLLECTION);
+
+const eventLogCollectionService = new ServerFirestoreCollectionService({
+  collectionRef: eventLogDbRef,
+  parseData: parseEventLogItem,
+  parseId: parseEventId,
+});
+
+export const eventLogService = new ServerEventLogService({eventLogCollectionService});

--- a/packages/sharedServer/src/services/feedItems.server.ts
+++ b/packages/sharedServer/src/services/feedItems.server.ts
@@ -119,7 +119,7 @@ export class ServerFeedItemsService {
    */
   public async deleteAllForUser(userId: UserId): AsyncResult<void> {
     // Fetch the IDs for all of the user's feed items.
-    const query = this.feedItemsCollectionService.getRef().where('userId', '==', userId);
+    const query = this.feedItemsCollectionService.getCollectionRef().where('userId', '==', userId);
     const queryResult = await this.feedItemsCollectionService.fetchQueryIds(query);
     if (!queryResult.success) {
       return prefixErrorResult(queryResult, 'Error fetching feed items to delete for user');

--- a/packages/sharedServer/src/services/feedSources.server.ts
+++ b/packages/sharedServer/src/services/feedSources.server.ts
@@ -30,7 +30,7 @@ export class ServerFeedSourcesService {
    * Fetches an existing feed source document from Firestore by its URL.
    */
   public async fetchByUrl(feedUrl: string): AsyncResult<FeedSource | null> {
-    const query = this.feedSourcesCollectionService.getRef().where('url', '==', feedUrl);
+    const query = this.feedSourcesCollectionService.getCollectionRef().where('url', '==', feedUrl);
     const maybeFeedSource = await this.feedSourcesCollectionService.fetchFirstQueryDoc(query);
     return prefixResultIfError(maybeFeedSource, 'Error fetching feed source by URL in Firestore');
   }

--- a/packages/sharedServer/src/services/firestore.server.ts
+++ b/packages/sharedServer/src/services/firestore.server.ts
@@ -1,4 +1,9 @@
-import type {CollectionReference, DocumentData, Query} from 'firebase-admin/firestore';
+import type {
+  CollectionReference,
+  DocumentData,
+  DocumentReference,
+  Query,
+} from 'firebase-admin/firestore';
 import {FieldValue} from 'firebase-admin/firestore';
 
 import {
@@ -37,8 +42,15 @@ export class ServerFirestoreCollectionService<
   /**
    * Returns the underlying Firestore collection reference.
    */
-  public getRef(): CollectionReference {
+  public getCollectionRef(): CollectionReference {
     return this.collectionRef;
+  }
+
+  /**
+   * Returns a Firestore document reference for the given child ID.
+   */
+  public getDocRef(docId: ItemId): DocumentReference {
+    return this.collectionRef.doc(docId);
   }
 
   /**
@@ -61,9 +73,9 @@ export class ServerFirestoreCollectionService<
   /**
    * Fetches all documents matching the Firestore query.
    */
-  async fetchQueryDocs(query: Query): AsyncResult<ItemData[]> {
+  async fetchQueryDocs(queryToFetch: Query): AsyncResult<ItemData[]> {
     const queryDataResult = await asyncTry(async () => {
-      const querySnapshot = await query.get();
+      const querySnapshot = await queryToFetch.get();
       return querySnapshot.docs.map((doc) => {
         const data = doc.data();
         const parseDataResult = this.parseData(data);
@@ -79,9 +91,9 @@ export class ServerFirestoreCollectionService<
    * Fetches data from the first document matching a Firestore query. If no documents match, returns
    * `null`.
    */
-  async fetchFirstQueryDoc(query: Query): AsyncResult<ItemData | null> {
+  async fetchFirstQueryDoc(queryToFetch: Query): AsyncResult<ItemData | null> {
     const queryDataResult = await asyncTry(async () => {
-      const querySnapshot = await query.limit(1).get();
+      const querySnapshot = await queryToFetch.limit(1).get();
       if (querySnapshot.empty) return null;
       const data = querySnapshot.docs[0].data();
       const parseDataResult = this.parseData(data);

--- a/packages/sharedServer/src/services/importQueue.server.ts
+++ b/packages/sharedServer/src/services/importQueue.server.ts
@@ -203,7 +203,9 @@ export class ServerImportQueueService {
     // TODO: Consider introducing a `batchDeleteAllForUser` method.
 
     // Fetch the IDs for all of the user's import queue items.
-    const query = this.importQueueCollectionService.getRef().where('userId', '==', userId);
+    const query = this.importQueueCollectionService
+      .getCollectionRef()
+      .where('userId', '==', userId);
     const queryResult = await this.importQueueCollectionService.fetchQueryIds(query);
     if (!queryResult.success) {
       return prefixErrorResult(queryResult, 'Error fetching import queue items to delete for user');

--- a/packages/sharedServer/src/services/userFeedSubscriptions.server.ts
+++ b/packages/sharedServer/src/services/userFeedSubscriptions.server.ts
@@ -32,7 +32,7 @@ export class ServerUserFeedSubscriptionsService {
    */
   public async fetchAllForUser(userId: UserId): AsyncResult<UserFeedSubscription[]> {
     const query = this.userFeedSubscriptionsCollectionService
-      .getRef()
+      .getCollectionRef()
       .where('userId', '==', userId);
     const queryResult = await this.userFeedSubscriptionsCollectionService.fetchQueryDocs(query);
     return prefixResultIfError(queryResult, 'Error fetching user feed subscriptions for user');
@@ -107,7 +107,7 @@ export class ServerUserFeedSubscriptionsService {
   public async deleteAllForUser(userId: UserId): AsyncResult<void> {
     // Fetch the IDs for all of the user's feed subscriptions.
     const query = this.userFeedSubscriptionsCollectionService
-      .getRef()
+      .getCollectionRef()
       .where('userId', '==', userId);
     const queryResult = await this.userFeedSubscriptionsCollectionService.fetchQueryIds(query);
     if (!queryResult.success) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive summary, here are the release notes:

- **New Features**
  - Enhanced event logging and tracking services
  - Improved Firestore collection management across client and server services

- **Changes**
  - Renamed several service methods for clarity:
    - `addFeedItem` → `createFeedItem`
    - `getFeedItem` → `fetchById`
  - Restructured event log and import queue services
  - Updated collection reference retrieval methods

- **Refactoring**
  - Introduced more modular service-oriented architecture
  - Simplified data handling and parsing across services
  - Enhanced error handling and logging mechanisms

- **Maintenance**
  - Removed deprecated event log service implementations
  - Updated type definitions and import structures

These changes represent a significant architectural improvement in service management and data handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->