### PR TITLE
Moved `tsc` output to ignored directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ packages/scripts/src/resources/
 
 # Build output.
 dist/
+distIgnore/
 
 # Environment variables.
 .env

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -14,7 +14,9 @@
 
     // Build is handled by Vite.
     "moduleResolution": "bundler",
-    "outDir": "./dist",
+
+    // Emit `tsc` output to an ignored directory to not override the Vite build output.
+    "outDir": "./distIgnore",
 
     // Import aliases.
     "baseUrl": ".",

--- a/packages/functions/tsconfig.json
+++ b/packages/functions/tsconfig.json
@@ -7,7 +7,9 @@
   "compilerOptions": {
     // Build is handled by esbuild.
     "moduleResolution": "bundler",
-    "outDir": "./dist",
+
+    // Emit `tsc` output to an ignored directory to not override the esbuild build output.
+    "outDir": "./distIgnore",
 
     // Import aliases.
     "baseUrl": ".",

--- a/packages/pwa/tsconfig.json
+++ b/packages/pwa/tsconfig.json
@@ -14,7 +14,9 @@
 
     // Build is handled by Vite.
     "moduleResolution": "bundler",
-    "outDir": "./dist",
+
+    // Emit `tsc` output to an ignored directory to not override the Vite build output.
+    "outDir": "./distIgnore",
 
     // Import aliases.
     "baseUrl": ".",

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -6,7 +6,9 @@
   "references": [{"path": "../shared"}],
 
   "compilerOptions": {
-    "outDir": "./dist"
+    // Emit `tsc` output to an ignored directory since we run scripts directly.
+    "outDir": "./distIgnore"
+
     // TODO: Get import aliases working by adding some build step.
     // Import aliases.
     // "baseUrl": ".",


### PR DESCRIPTION
Avoids overriding the actual build output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude `distIgnore/` directory
	- Modified TypeScript configuration for multiple packages to use `distIgnore` as the output directory instead of `dist`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->