### PR TITLE
Add `Popover` and move view options into one

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -7,6 +7,7 @@
     "@conductor/shared": "workspace:*",
     "@conductor/shared-client": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-popover": "^1.1.11",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",

--- a/packages/pwa/src/components/atoms/Icon.tsx
+++ b/packages/pwa/src/components/atoms/Icon.tsx
@@ -38,6 +38,12 @@ function toLucideIconName(name: IconName): LucideIconName {
       return 'star';
     case IconName.RetryImport:
       return 'refresh-cw';
+    case IconName.SlidersHorizontal:
+      return 'sliders-horizontal';
+    case IconName.ArrowUp:
+      return 'arrow-up';
+    case IconName.ArrowDown:
+      return 'arrow-down';
     default:
       assertNever(name);
   }

--- a/packages/pwa/src/components/atoms/Popover.tsx
+++ b/packages/pwa/src/components/atoms/Popover.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import * as React from 'react';
+
+import {cn} from '@src/lib/utils.pwa';
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({className, align = 'center', sideOffset = 4, ...props}, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-[--radix-popover-content-transform-origin] rounded-md border p-4 shadow-md outline-none',
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export {Popover, PopoverTrigger, PopoverContent};

--- a/packages/pwa/src/components/views/ViewOptionsDialog.tsx
+++ b/packages/pwa/src/components/views/ViewOptionsDialog.tsx
@@ -60,13 +60,13 @@ export const ViewOptionsDialog: React.FC<{
         <ButtonIcon
           name={IconName.SlidersHorizontal}
           size={32}
-          tooltip="Display options"
+          tooltip="Customize view"
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           onClick={() => {}}
         />
       </PopoverTrigger>
 
-      <PopoverContent className="w-auto">
+      <PopoverContent className="w-auto" align="end" side="bottom">
         <div className="flex flex-col gap-4 p-4">
           <div className="flex items-center justify-between gap-2">
             <label htmlFor="groupBy" className="text-sm font-medium">

--- a/packages/pwa/src/components/views/ViewOptionsDialog.tsx
+++ b/packages/pwa/src/components/views/ViewOptionsDialog.tsx
@@ -10,13 +10,7 @@ import type {
 import {SORT_BY_CREATED_TIME_DESC_OPTION} from '@shared/types/views.types';
 
 import {ButtonIcon} from '@src/components/atoms/ButtonIcon';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@src/components/atoms/Dialog';
+import {Popover, PopoverContent, PopoverTrigger} from '@src/components/atoms/Popover';
 
 export const ViewOptionsDialog: React.FC<{
   sortBy: readonly ViewSortByOption[];
@@ -61,21 +55,18 @@ export const ViewOptionsDialog: React.FC<{
     firstSortByOption.direction === 'asc' ? 'Sort Ascending' : 'Sort Descending';
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
         <ButtonIcon
           name={IconName.SlidersHorizontal}
           size={32}
           tooltip="Display options"
-          onClick={() => true} // onClick required by ButtonIcon, dialog handles open
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          onClick={() => {}}
         />
-      </DialogTrigger>
+      </PopoverTrigger>
 
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Display options</DialogTitle>
-        </DialogHeader>
-
+      <PopoverContent className="w-auto">
         <div className="flex flex-col gap-4 p-4">
           <div className="flex items-center justify-between gap-2">
             <label htmlFor="groupBy" className="text-sm font-medium">
@@ -117,7 +108,7 @@ export const ViewOptionsDialog: React.FC<{
             </div>
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </PopoverContent>
+    </Popover>
   );
 };

--- a/packages/pwa/src/components/views/ViewOptionsDialog.tsx
+++ b/packages/pwa/src/components/views/ViewOptionsDialog.tsx
@@ -55,7 +55,7 @@ export const ViewOptionsDialog: React.FC<{
     firstSortByOption.direction === 'asc' ? 'Sort Ascending' : 'Sort Descending';
 
   return (
-    <Popover>
+    <Popover modal>
       <PopoverTrigger asChild>
         <ButtonIcon
           name={IconName.SlidersHorizontal}

--- a/packages/pwa/src/components/views/ViewOptionsDialog.tsx
+++ b/packages/pwa/src/components/views/ViewOptionsDialog.tsx
@@ -1,0 +1,123 @@
+import {toViewGroupByOptionText, toViewSortByOptionText} from '@shared/lib/views.shared';
+
+import {IconName} from '@shared/types/icons.types';
+import type {
+  ViewGroupByField,
+  ViewGroupByOption,
+  ViewSortByField,
+  ViewSortByOption,
+} from '@shared/types/views.types';
+import {SORT_BY_CREATED_TIME_DESC_OPTION} from '@shared/types/views.types';
+
+import {ButtonIcon} from '@src/components/atoms/ButtonIcon';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@src/components/atoms/Dialog';
+
+export const ViewOptionsDialog: React.FC<{
+  sortBy: readonly ViewSortByOption[];
+  groupBy: readonly ViewGroupByOption[];
+  onSortByChange: React.Dispatch<React.SetStateAction<ViewSortByOption[]>>;
+  onGroupByChange: React.Dispatch<React.SetStateAction<ViewGroupByOption[]>>;
+}> = ({sortBy, groupBy, onSortByChange, onGroupByChange}) => {
+  const firstSortByOption = sortBy[0] ?? SORT_BY_CREATED_TIME_DESC_OPTION;
+  const firstGroupByOption = groupBy.length === 0 ? null : groupBy[0].field;
+
+  const handleGroupByChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+    onGroupByChange(
+      event.target.value === 'none' ? [] : [{field: event.target.value as ViewGroupByField}]
+    );
+  };
+
+  const handleSortFieldChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+    onSortByChange([
+      {
+        field: event.target.value as ViewSortByField,
+        direction: firstSortByOption.direction,
+      },
+    ]);
+  };
+
+  const handleSortDirectionToggle = (): void => {
+    onSortByChange((prevOptions) => {
+      const currentSortOption = prevOptions[0] ?? SORT_BY_CREATED_TIME_DESC_OPTION;
+      const newDirection = currentSortOption.direction === 'asc' ? 'desc' : 'asc';
+      return [
+        {
+          field: currentSortOption.field,
+          direction: newDirection,
+        },
+      ];
+    });
+  };
+
+  const sortDirectionIcon =
+    firstSortByOption.direction === 'asc' ? IconName.ArrowUp : IconName.ArrowDown;
+  const sortDirectionTooltip =
+    firstSortByOption.direction === 'asc' ? 'Sort Ascending' : 'Sort Descending';
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <ButtonIcon
+          name={IconName.SlidersHorizontal}
+          size={32}
+          tooltip="Display options"
+          onClick={() => true} // onClick required by ButtonIcon, dialog handles open
+        />
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Display options</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <label htmlFor="groupBy" className="text-sm font-medium">
+              Group by
+            </label>
+            <select
+              id="groupBy"
+              value={firstGroupByOption ?? 'none'}
+              onChange={handleGroupByChange}
+              className="rounded border border-stone-300 p-1 text-sm"
+            >
+              <option value="none">None</option>
+              <option value="type">{toViewGroupByOptionText('type')}</option>
+              <option value="importState">{toViewGroupByOptionText('importState')}</option>
+            </select>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <label htmlFor="sortField" className="text-sm font-medium">
+              Sort by
+            </label>
+            <div className="flex items-center gap-1">
+              <select
+                id="sortField"
+                value={firstSortByOption.field}
+                onChange={handleSortFieldChange}
+                className="rounded border border-stone-300 p-1 text-sm"
+              >
+                <option value="createdTime">{toViewSortByOptionText('createdTime')}</option>
+                <option value="lastUpdatedTime">{toViewSortByOptionText('lastUpdatedTime')}</option>
+                <option value="title">{toViewSortByOptionText('title')}</option>
+              </select>
+              <ButtonIcon
+                name={sortDirectionIcon}
+                size={24}
+                tooltip={sortDirectionTooltip}
+                onClick={handleSortDirectionToggle}
+                aria-label="Toggle sort direction"
+              />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/shared/src/types/icons.types.ts
+++ b/packages/shared/src/types/icons.types.ts
@@ -7,6 +7,9 @@ export enum IconName {
   Save = 'SAVE',
   Star = 'STAR',
   RetryImport = 'RETRY_IMPORT',
+  SlidersHorizontal = 'SLIDERS_HORIZONTAL',
+  ArrowUp = 'ARROW_UP',
+  ArrowDown = 'ARROW_DOWN',
 }
 
 export type IconSize = 16 | 24 | 32 | 40;

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,6 +471,7 @@ __metadata:
     "@conductor/shared": "workspace:*"
     "@conductor/shared-client": "workspace:*"
     "@radix-ui/react-dialog": "npm:^1.1.6"
+    "@radix-ui/react-popover": "npm:^1.1.11"
     "@radix-ui/react-slot": "npm:^1.1.2"
     "@radix-ui/react-toast": "npm:^1.2.6"
     "@radix-ui/react-tooltip": "npm:^1.1.8"
@@ -3518,6 +3519,39 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/7d12e76818763d592c331277ef62b197e2e64945307e650bd058f0090e5ae48bbd07691b23b7e9e977901ef4eadcb3e2d5eaeb17a13859083384be83fc1292c7
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-popover@npm:^1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-popover@npm:1.1.11"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.2"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.7"
+    "@radix-ui/react-focus-guards": "npm:1.1.2"
+    "@radix-ui/react-focus-scope": "npm:1.1.4"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-popper": "npm:1.2.4"
+    "@radix-ui/react-portal": "npm:1.1.6"
+    "@radix-ui/react-presence": "npm:1.1.4"
+    "@radix-ui/react-primitive": "npm:2.1.0"
+    "@radix-ui/react-slot": "npm:1.2.0"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.6.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/0d15550d9127726b5a815ce04e51e3ccdf80f696e484d0b4a1683e6349600c4d62369759d612f429866d37e314b6fec41a0eebdc1c66ffd894affe63bee95a72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a popover UI component for displaying modal dialogs.
  - Added a dialog for customizing view sorting and grouping options, accessible via a new icon button.
- **Enhancements**
  - Expanded icon support with new icons for sliders, arrow up, and arrow down.
  - Improved view customization by separating sorting and grouping controls.
- **Chores**
  - Updated dependencies to include Radix UI popover support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->