### PR TITLE
Default date groups in view list

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -78,6 +78,9 @@ Key data collections in Firestore:
 - Secure API key management
 - CORS configuration for storage
 
+### UI preferences
+- Use sentence case for headers
+
 ## Development Guidelines
 
 ### Testing

--- a/packages/pwa/src/components/atoms/Popover.tsx
+++ b/packages/pwa/src/components/atoms/Popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-[--radix-popover-content-transform-origin] rounded-md border p-4 shadow-md outline-none',
+        'bg-background text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-[--radix-popover-content-transform-origin] rounded-md border p-4 shadow-md outline-none',
         className
       )}
       {...props}

--- a/packages/pwa/src/components/views/View.tsx
+++ b/packages/pwa/src/components/views/View.tsx
@@ -103,6 +103,12 @@ function useSortedFeedItems(
   return sortedItems;
 }
 
+const getDateGroupKey = (date: Date | string): string => {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  // TODO: Use better names for group keys.
+  return d.toISOString().split('T')[0]; // YYYY-MM-DD format
+};
+
 /**
  * Returns a grouped list of feed items, keyed by values of the group field. Returns `null` if no
  * group field is provided.
@@ -113,7 +119,7 @@ function useGroupedFeedItems(
   feedItems: FeedItem[],
   groupByField: ViewGroupByField | null
 ): Record<string, FeedItem[]> | null {
-  const groupedItems = useMemo(() => {
+  return useMemo(() => {
     if (groupByField === null) {
       return null;
     }
@@ -132,7 +138,29 @@ function useGroupedFeedItems(
 
       case 'importState':
         for (const item of feedItems) {
-          const groupKey = item.importState?.status || 'UNKNOWN';
+          const groupKey = item.importState.status;
+          if (!groupedItems[groupKey]) {
+            groupedItems[groupKey] = [];
+          }
+          groupedItems[groupKey].push(item);
+        }
+        return groupedItems;
+
+      case 'createdDate':
+        // TODO: Handle timezones.
+        for (const item of feedItems) {
+          const groupKey = getDateGroupKey(item.createdTime);
+          if (!groupedItems[groupKey]) {
+            groupedItems[groupKey] = [];
+          }
+          groupedItems[groupKey].push(item);
+        }
+        return groupedItems;
+
+      case 'lastUpdatedDate':
+        // TODO: Handle timezones.
+        for (const item of feedItems) {
+          const groupKey = getDateGroupKey(item.lastUpdatedTime);
           if (!groupedItems[groupKey]) {
             groupedItems[groupKey] = [];
           }
@@ -144,8 +172,6 @@ function useGroupedFeedItems(
         assertNever(groupByField);
     }
   }, [feedItems, groupByField]);
-
-  return groupedItems;
 }
 
 const ViewListItem: React.FC<{

--- a/packages/shared/src/lib/views.shared.ts
+++ b/packages/shared/src/lib/views.shared.ts
@@ -5,12 +5,25 @@ import {TriageStatus} from '@shared/types/feedItems.types';
 import {QueryFilterOp} from '@shared/types/query.types';
 import {SystemTagId} from '@shared/types/tags.types';
 import {NavItemId} from '@shared/types/urls.types';
-import type {View, ViewGroupByField, ViewSortByField} from '@shared/types/views.types';
+import type {
+  View,
+  ViewGroupByField,
+  ViewGroupByOption,
+  ViewSortByField,
+} from '@shared/types/views.types';
 import {
   SORT_BY_CREATED_TIME_DESC_OPTION,
   SORT_BY_LAST_UPDATED_TIME_DESC_OPTION,
   ViewType,
 } from '@shared/types/views.types';
+
+const GROUP_BY_CREATED_DATE_OPTION: ViewGroupByOption = {
+  field: 'createdDate',
+};
+
+const GROUP_BY_LAST_UPDATED_DATE_OPTION: ViewGroupByOption = {
+  field: 'lastUpdatedDate',
+};
 
 const ALL_VIEW_CONFIGS: Record<ViewType, View<FeedItem>> = {
   [ViewType.Untriaged]: {
@@ -18,28 +31,28 @@ const ALL_VIEW_CONFIGS: Record<ViewType, View<FeedItem>> = {
     type: ViewType.Untriaged,
     filters: [{field: 'triageStatus', op: QueryFilterOp.Equals, value: TriageStatus.Untriaged}],
     sortBy: [SORT_BY_CREATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_CREATED_DATE_OPTION],
   },
   [ViewType.Saved]: {
     name: 'Saved',
     type: ViewType.Saved,
     filters: [{field: 'triageStatus', op: QueryFilterOp.Equals, value: TriageStatus.Saved}],
     sortBy: [SORT_BY_LAST_UPDATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_LAST_UPDATED_DATE_OPTION],
   },
   [ViewType.Done]: {
     name: 'Done',
     type: ViewType.Done,
     filters: [{field: 'triageStatus', op: QueryFilterOp.Equals, value: TriageStatus.Done}],
     sortBy: [SORT_BY_LAST_UPDATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_LAST_UPDATED_DATE_OPTION],
   },
   [ViewType.Trashed]: {
     name: 'Trashed',
     type: ViewType.Trashed,
     filters: [{field: 'triageStatus', op: QueryFilterOp.Equals, value: TriageStatus.Trashed}],
     sortBy: [SORT_BY_LAST_UPDATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_LAST_UPDATED_DATE_OPTION],
   },
   [ViewType.Unread]: {
     name: 'Unread',
@@ -50,7 +63,7 @@ const ALL_VIEW_CONFIGS: Record<ViewType, View<FeedItem>> = {
       {field: `tagIds.${SystemTagId.Unread}` as any, op: QueryFilterOp.Equals, value: true},
     ],
     sortBy: [SORT_BY_CREATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_CREATED_DATE_OPTION],
   },
   [ViewType.Starred]: {
     name: 'Starred',
@@ -61,14 +74,14 @@ const ALL_VIEW_CONFIGS: Record<ViewType, View<FeedItem>> = {
       {field: `tagIds.${SystemTagId.Starred}` as any, op: QueryFilterOp.Equals, value: true},
     ],
     sortBy: [SORT_BY_CREATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_CREATED_DATE_OPTION],
   },
   [ViewType.All]: {
     name: 'All',
     type: ViewType.All,
     filters: [],
     sortBy: [SORT_BY_CREATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_CREATED_DATE_OPTION],
   },
   [ViewType.Today]: {
     name: 'Today',
@@ -81,7 +94,7 @@ const ALL_VIEW_CONFIGS: Record<ViewType, View<FeedItem>> = {
       },
     ],
     sortBy: [SORT_BY_CREATED_TIME_DESC_OPTION],
-    groupBy: [],
+    groupBy: [GROUP_BY_CREATED_DATE_OPTION],
   },
 };
 
@@ -177,6 +190,10 @@ export function toViewGroupByOptionText(viewGroupByField: ViewGroupByField): str
       return 'Type';
     case 'importState':
       return 'Import state';
+    case 'createdDate':
+      return 'Created date';
+    case 'lastUpdatedDate':
+      return 'Last updated date';
     default:
       assertNever(viewGroupByField);
   }

--- a/packages/shared/src/types/views.types.ts
+++ b/packages/shared/src/types/views.types.ts
@@ -26,7 +26,7 @@ interface ViewFilter<T> {
   readonly value: unknown;
 }
 
-export type ViewGroupByField = 'type' | 'importState';
+export type ViewGroupByField = 'type' | 'importState' | 'createdDate' | 'lastUpdatedDate';
 
 export interface ViewGroupByOption {
   readonly field: ViewGroupByField;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to group feed items by "Created date" and "Last updated date" in views.
  - Updated default grouping options for several views to use these new date-based groupings.

- **Style**
  - Updated popover component colors to improve visual consistency.

- **Documentation**
  - Added a guideline to use sentence case for headers in the UI preferences documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->