### PR TITLE
Removed type hacks in `package.json`

### DIFF
--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -20,18 +20,17 @@
     "validate": "yarn run validate:lint && yarn run validate:types && yarn run validate:format",
     "validate:lint": "eslint src",
     "validate:lint:fix": "eslint src --fix",
-    "validate:types": "yarn run hack-type && tsc --build",
+    "validate:types": "tsc --build",
     "validate:format": "prettier --check 'src/**/*.{js,ts,json}'",
     "format": "prettier --write 'src/**/*.{js,ts,json}'",
     "clean": "rm -rf dist/ distIgnore/",
     "ci": "rm -rf node_modules/ && yarn install",
-    "build": "yarn run clean && yarn run hack-type && esbuild src/index.ts --bundle --platform=node --target=node22 --outfile=dist/index.js --external:firebase-admin --external:firebase-functions",
+    "build": "yarn run clean && esbuild src/index.ts --bundle --platform=node --target=node22 --outfile=dist/index.js --external:firebase-admin --external:firebase-functions",
     "serve": "yarn run build && firebase emulators:start --only functions",
     "shell": "yarn run build && firebase functions:shell",
     "start": "yarn run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "test": "echo 'No tests implemented'",
-    "hack-type": "test -f ../../node_modules/@types/request/index.d.ts && sed -i.bak '/setCookie(/d' ../../node_modules/@types/request/index.d.ts || true"
+    "test": "echo 'No tests implemented'"
   }
 }

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -43,17 +43,16 @@
     "validate": "yarn run validate:lint && yarn run validate:types && yarn run validate:format",
     "validate:lint": "eslint src",
     "validate:lint:fix": "eslint src --fix",
-    "validate:types": "yarn run hack-cookie-type && tsc --build",
+    "validate:types": "tsc --build",
     "validate:format": "prettier --check 'src/**/*.{js,jsx,ts,tsx,json,css,svg}'",
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,json,css,svg}'",
     "start": "vite",
     "clean": "rm -rf dist/ distIgnore/",
     "ci": "rm -rf node_modules/ && yarn install",
-    "build": "yarn run clean && yarn run hack-cookie-type && vite build",
+    "build": "yarn run clean && vite build",
     "preview": "vite preview",
     "deploy": "firebase deploy --only hosting",
-    "test": "echo 'No tests implemented'",
-    "hack-cookie-type": "test -f ../../node_modules/@types/request/index.d.ts && sed -i.bak '/setCookie(/d' ../../node_modules/@types/request/index.d.ts || true"
+    "test": "echo 'No tests implemented'"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
Not needed since adding `skipLibCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified build and type validation scripts by removing custom script steps from the workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->