### PR TITLE
Added YouTube as a `FeedSource`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,12 @@ const NO_SHARED_SERVER_IMPORT_PATTERN = {
   message: 'Importing from the `@sharedServer` package is not allowed in this package.',
 };
 
+// There is a separate override below that allows test utils to be imported in test files.
+const NO_TEST_UTILS_IMPORT_PATTERN = {
+  group: ['@shared/lib/testUtils.shared'],
+  message: 'Test utils can only be imported in test files.',
+};
+
 function makeSharedRules({
   disallowFirebaseAdminImports,
   disallowFirebaseClientImports,
@@ -103,6 +109,7 @@ function makeSharedRules({
           disallowFirebaseClientImports ? NO_FIREBASE_CLIENT_IMPORT_PATTERN : null,
           disallowSharedClientImports ? NO_SHARED_CLIENT_IMPORT_PATTERN : null,
           disallowSharedServerImports ? NO_SHARED_SERVER_IMPORT_PATTERN : null,
+          NO_TEST_UTILS_IMPORT_PATTERN,
         ].filter((p) => p !== null),
       },
     ],
@@ -291,5 +298,13 @@ export default tseslint.config(
       disallowFirebaseAdminImports: false,
       disallowSharedServerImports: false,
     }),
+  },
+
+  // Clear the restriction on importing test utils in test files.
+  {
+    files: ['**/*.test.ts', '**/*.test.tsx'],
+    rules: {
+      'no-restricted-imports': ['error', {paths: []}],
+    },
   }
 );

--- a/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
+++ b/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
@@ -54,8 +54,8 @@ const FeedAdder: React.FC = () => {
     async (youtubeChannelUrl: string): Promise<void> => {
       setPending();
 
-      const url = new URL(youtubeChannelUrl);
-      const subscribeResult = await userFeedSubscriptionsService.subscribeToYouTubeChannel(url);
+      const subscribeResult =
+        await userFeedSubscriptionsService.subscribeToYouTubeChannel(youtubeChannelUrl);
       if (!subscribeResult.success) {
         setError(prefixError(subscribeResult.error, 'Failed to subscribe to YouTube channel'));
         return;

--- a/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
+++ b/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
@@ -53,9 +53,18 @@ const FeedAdder: React.FC = () => {
   const handleSubscribeToYouTubeChannel = useCallback(
     async (youtubeChannelUrl: string): Promise<void> => {
       setPending();
-      setError(new Error('TODO: Not implemented'));
+
+      const url = new URL(youtubeChannelUrl);
+      const subscribeResult = await userFeedSubscriptionsService.subscribeToYouTubeChannel(url);
+      if (!subscribeResult.success) {
+        setError(prefixError(subscribeResult.error, 'Failed to subscribe to YouTube channel'));
+        return;
+      }
+
+      setSuccess(undefined);
+      setUrlInputValue('');
     },
-    [setError, setPending]
+    [setError, setPending, setSuccess, userFeedSubscriptionsService]
   );
 
   const handleSubscribeToDummyFeed = useCallback(async (): Promise<void> => {
@@ -113,7 +122,7 @@ const FeedAdder: React.FC = () => {
             variant="default"
             onClick={async () =>
               void handleSubscribeToYouTubeChannel(
-                'https://lorem-rss.herokuapp.com/feed?unit=second&interval=30'
+                'https://www.youtube.com/channel/UCndkjnoQawp7Tjy1uNj53yQ'
               )
             }
           >

--- a/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
+++ b/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
@@ -50,6 +50,14 @@ const FeedAdder: React.FC = () => {
     [setError, setPending, setSuccess, userFeedSubscriptionsService]
   );
 
+  const handleSubscribeToYouTubeChannel = useCallback(
+    async (youtubeChannelUrl: string): Promise<void> => {
+      setPending();
+      setError(new Error('TODO: Not implemented'));
+    },
+    [setError, setPending]
+  );
+
   const handleSubscribeToDummyFeed = useCallback(async (): Promise<void> => {
     setPending();
     setError(new Error('TODO: Not implemented'));
@@ -95,6 +103,16 @@ const FeedAdder: React.FC = () => {
             variant="default"
             onClick={async () =>
               void handleSubscribeToRssFeedByUrl(
+                'https://lorem-rss.herokuapp.com/feed?unit=second&interval=30'
+              )
+            }
+          >
+            Lorem RSS feed w/ 30s updates
+          </Button>
+          <Button
+            variant="default"
+            onClick={async () =>
+              void handleSubscribeToYouTubeChannel(
                 'https://lorem-rss.herokuapp.com/feed?unit=second&interval=30'
               )
             }

--- a/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
+++ b/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
@@ -126,7 +126,7 @@ const FeedAdder: React.FC = () => {
               )
             }
           >
-            Lorem RSS feed w/ 30s updates
+            Personal YouTube channel
           </Button>
           <Button variant="default" onClick={async () => void handleSubscribeToDummyFeed()}>
             Dummy feed

--- a/packages/shared/src/lib/feedItems.shared.ts
+++ b/packages/shared/src/lib/feedItems.shared.ts
@@ -2,6 +2,7 @@ import {logger} from '@shared/services/logger.shared';
 
 import {prefixError, upgradeUnknownError} from '@shared/lib/errorUtils.shared';
 import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
+import {parseUrl} from '@shared/lib/urls.shared';
 import {assertNever} from '@shared/lib/utils.shared';
 
 import type {DeliverySchedule} from '@shared/types/deliverySchedules.types';
@@ -167,8 +168,10 @@ export class SharedFeedItemHelpers {
   }
 
   public static validateUrl(url: string): Result<void> {
-    // Parse the URL to validate its structure.
-    const parsedUrl = new URL(url);
+    const parsedUrl = parseUrl(url);
+    if (!parsedUrl) {
+      return makeErrorResult(new Error('Invalid URL'));
+    }
 
     // Only allow HTTPS protocols.
     // TODO: Consider allowing other protocols like `http:` and `chrome:` as well.

--- a/packages/shared/src/lib/feedSources.shared.ts
+++ b/packages/shared/src/lib/feedSources.shared.ts
@@ -1,0 +1,35 @@
+import {makeUuid} from '@shared/lib/utils.shared';
+
+import {FeedSourceType, type FeedSource, type FeedSourceId} from '@shared/types/feedSources.types';
+
+export function makeFeedSourceId(): FeedSourceId {
+  return makeUuid<FeedSourceId>();
+}
+
+export function makeRssFeedSource(
+  newItemArgs: Omit<FeedSource, 'type' | 'feedSourceId' | 'createdTime' | 'lastUpdatedTime'>
+): FeedSource {
+  return {
+    type: FeedSourceType.RSS,
+    feedSourceId: makeFeedSourceId(),
+    url: newItemArgs.url,
+    title: newItemArgs.title,
+    // TODO(timestamps): Use server timestamps instead.
+    createdTime: new Date(),
+    lastUpdatedTime: new Date(),
+  };
+}
+
+export function makeYouTubeFeedSource(
+  newItemArgs: Omit<FeedSource, 'type' | 'feedSourceId' | 'createdTime' | 'lastUpdatedTime'>
+): FeedSource {
+  return {
+    type: FeedSourceType.YouTube,
+    feedSourceId: makeFeedSourceId(),
+    url: newItemArgs.url,
+    title: newItemArgs.title,
+    // TODO(timestamps): Use server timestamps instead.
+    createdTime: new Date(),
+    lastUpdatedTime: new Date(),
+  };
+}

--- a/packages/shared/src/lib/testUtils.shared.ts
+++ b/packages/shared/src/lib/testUtils.shared.ts
@@ -1,0 +1,24 @@
+import type {Result} from '@shared/types/results.types';
+
+/**
+ * A convenience function to quickly assert that a result is successful and has the expected value.
+ */
+export function expectResultValue<T>(result: Result<T>, expectedValue: T): void {
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.value).toBe(expectedValue);
+  }
+}
+
+/**
+ * A convenience method to quickly unwrap a result, or throw an error if no result to unwrap.
+ *
+ * WARNING: This method is unsafe. It throws an error if the result is not successful.
+ */
+export function unwrapOrThrow<T>(result: Result<T>): T {
+  if (result.success) return result.value;
+
+  // This is a test utility function, so it is okay to throw.
+  // eslint-disable-next-line no-restricted-syntax
+  throw new Error('Result was not successful');
+}

--- a/packages/shared/src/lib/testUtils.shared.ts
+++ b/packages/shared/src/lib/testUtils.shared.ts
@@ -1,12 +1,27 @@
 import type {Result} from '@shared/types/results.types';
 
 /**
- * A convenience function to quickly assert that a result is successful and has the expected value.
+ * A convenience function to quickly assert that a {@link Result} is successful and has the expected
+ * value.
  */
 export function expectResultValue<T>(result: Result<T>, expectedValue: T): void {
   expect(result.success).toBe(true);
   if (result.success) {
     expect(result.value).toBe(expectedValue);
+  }
+}
+
+/**
+ * A convenience function to quickly assert that a {@link Result} is not successful and has the
+ * expected error message.
+ */
+export function expectErrorResult<T>(
+  result: Result<T>,
+  expectedErrorMessage: string | RegExp
+): void {
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.message).toMatch(expectedErrorMessage);
   }
 }
 

--- a/packages/shared/src/lib/youtube.shared.test.ts
+++ b/packages/shared/src/lib/youtube.shared.test.ts
@@ -1,0 +1,147 @@
+import {expectResultValue, unwrapOrThrow} from '@shared/lib/testUtils.shared';
+import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youTube.shared';
+
+import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
+
+import type {YouTubeChannelId} from '@shared/types/youtube.types';
+
+const VALID_CHANNEL_ID = unwrapOrThrow<YouTubeChannelId>(
+  parseYouTubeChannelId('UCndkjnoQawp7Tjy1uNj53yQ')
+);
+const VALID_HANDLE = unwrapOrThrow<YouTubeChannelId>(parseYouTubeChannelId('jacobwenger8649'));
+
+describe('getYouTubeChannelId', () => {
+  it.only('should extract channel ID from /channel/ URLs', () => {
+    const url = `https://www.youtube.com/channel/${VALID_CHANNEL_ID}`;
+    const result = getYouTubeChannelId(url);
+    expectResultValue(result, VALID_CHANNEL_ID);
+  });
+
+  it('should extract channel ID from /@handle URLs', () => {
+    const url = `https://www.youtube.com/@${VALID_HANDLE}`;
+    const result = getYouTubeChannelId(url);
+    expectResultValue(result, VALID_HANDLE);
+  });
+
+  it('should return null for /c/ URLs', () => {
+    const url = `https://www.youtube.com/c/${VALID_HANDLE}`;
+    const result = getYouTubeChannelId(url);
+    expectResultValue(result, null);
+  });
+
+  it('should return null for unrelated YouTube URLs', () => {
+    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'; // Not a channel URL
+    const result = getYouTubeChannelId(url);
+    expectResultValue(result, null);
+  });
+
+  it('should return null for non-YouTube URLs', () => {
+    const url = `https://example.com/channel/${VALID_CHANNEL_ID}`; // Not a YouTube URL
+    const result = getYouTubeChannelId(url);
+    expectResultValue(result, null);
+  });
+
+  it('should handle mobile m.youtube.com URLs', () => {
+    const url = `https://m.youtube.com/channel/${VALID_CHANNEL_ID}`;
+    const result = getYouTubeChannelId(url);
+    expectResultValue(result, VALID_CHANNEL_ID);
+  });
+
+  it('should return null for m.youtube.com handle URLs (mobile not supported)', () => {
+    const url = `https://m.youtube.com/@${VALID_HANDLE}`;
+    const result = getYouTubeChannelId(url);
+    expectResultValue(result, null);
+  });
+
+  it('should return null for empty string', () => {
+    const result = getYouTubeChannelId('');
+    expectResultValue(result, null);
+  });
+
+  it('should handle various URL formats', () => {
+    const urlsToTest = [
+      `https://youtube.com/@${VALID_HANDLE}`, // No www.
+      `youtube.com/@${VALID_HANDLE}`, // No protocol. No www.
+      `www.youtube.com/@${VALID_HANDLE}`, // No protocol.
+      `m.youtube.com/@${VALID_HANDLE}`, // Mobile.
+    ];
+
+    for (const url of urlsToTest) {
+      const result = getYouTubeChannelId(url);
+      expectResultValue(result, VALID_HANDLE);
+    }
+  });
+});
+
+describe('isYouTubeChannelUrl', () => {
+  it('should return true for /channel/ URLs', () => {
+    expect(isYouTubeChannelUrl(`https://www.youtube.com/channel/${VALID_CHANNEL_ID}`)).toBe(true);
+  });
+
+  it('should return true for /@handle URLs', () => {
+    expect(isYouTubeChannelUrl(`https://www.youtube.com/@${VALID_HANDLE}`)).toBe(true);
+  });
+
+  it('should return false for /c/ URLs (not yet supported)', () => {
+    expect(isYouTubeChannelUrl(`https://www.youtube.com/c/${VALID_HANDLE}`)).toBe(false);
+  });
+
+  it('should return false for unrelated YouTube URLs', () => {
+    expect(isYouTubeChannelUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(false);
+  });
+
+  it('should return false for non-YouTube URLs', () => {
+    expect(isYouTubeChannelUrl(`https://example.com/channel/${VALID_CHANNEL_ID}`)).toBe(false);
+  });
+
+  it('should return false for m.youtube.com URLs (mobile not supported)', () => {
+    expect(isYouTubeChannelUrl(`https://m.youtube.com/channel/${VALID_CHANNEL_ID}`)).toBe(false);
+  });
+
+  it('should return false for m.youtube.com handle URLs (mobile not supported)', () => {
+    expect(isYouTubeChannelUrl(`https://m.youtube.com/@${VALID_HANDLE}`)).toBe(false);
+  });
+
+  it('should handle no protocol', () => {
+    expect(isYouTubeChannelUrl(`www.youtube.com/@${VALID_HANDLE}`)).toBe(true);
+  });
+
+  it('should return false for empty string', () => {
+    expect(isYouTubeChannelUrl('')).toBe(false);
+  });
+});
+
+describe('parseYouTubeChannelId', () => {
+  it('should succeed for a valid channel ID', () => {
+    const result = parseYouTubeChannelId(VALID_CHANNEL_ID);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value).toBe(VALID_CHANNEL_ID);
+    }
+  });
+
+  it('should succeed for a valid handle', () => {
+    const result = parseYouTubeChannelId(VALID_HANDLE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value).toBe(VALID_HANDLE);
+    }
+  });
+
+  it('should fail for an empty string', () => {
+    const result = parseYouTubeChannelId('');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toMatch(/Invalid YouTube channel ID/);
+    }
+  });
+
+  it('should fail for a string longer than 128 characters', () => {
+    const longId = 'a'.repeat(129);
+    const result = parseYouTubeChannelId(longId);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toMatch(/Invalid YouTube channel ID/);
+    }
+  });
+});

--- a/packages/shared/src/lib/youtube.shared.test.ts
+++ b/packages/shared/src/lib/youtube.shared.test.ts
@@ -1,5 +1,5 @@
 import {expectErrorResult, expectResultValue, unwrapOrThrow} from '@shared/lib/testUtils.shared';
-import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youTube.shared';
+import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youtube.shared';
 
 import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
 

--- a/packages/shared/src/lib/youtube.shared.test.ts
+++ b/packages/shared/src/lib/youtube.shared.test.ts
@@ -1,5 +1,5 @@
-import {expectResultValue, unwrapOrThrow} from '@shared/lib/testUtils.shared';
-import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youtube.shared';
+import {expectErrorResult, expectResultValue, unwrapOrThrow} from '@shared/lib/testUtils.shared';
+import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youTube.shared';
 
 import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
 
@@ -10,107 +10,79 @@ const VALID_CHANNEL_ID = unwrapOrThrow<YouTubeChannelId>(
 );
 const VALID_HANDLE = unwrapOrThrow<YouTubeChannelId>(parseYouTubeChannelId('jacobwenger8649'));
 
+const VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE = [
+  `https://www.youtube.com/@${VALID_HANDLE}`, // Handle.
+  `https://youtube.com/@${VALID_HANDLE}`, // No prefix.
+  `https://www.youtube.com/c/${VALID_HANDLE}`, // Legacy /c/ URL.
+  `www.youtube.com/@${VALID_HANDLE}`, // No protocol.
+  `youtube.com/@${VALID_HANDLE}`, // No prefix or protocol.
+  `m.youtube.com/@${VALID_HANDLE}`, // Mobile no prefix or protocol.
+];
+
+const VALID_YOUTUBE_CHANNEL_URLS_WITH_CHANNEL_ID = [
+  `https://www.youtube.com/channel/${VALID_CHANNEL_ID}`, // Channel ID.
+  `https://m.youtube.com/channel/${VALID_CHANNEL_ID}`, // Mobile.
+];
+
+const NON_YOUTUBE_URLS = [
+  `https://example.com/channel/${VALID_CHANNEL_ID}`, // Non-YouTube URL.
+  'foo', // Invalid URL.
+  '', // Empty string.
+];
+
+const YOUTUBE_VIDEO_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+
 describe('getYouTubeChannelId', () => {
-  it.each([
-    `https://www.youtube.com/@${VALID_HANDLE}`, // Handle.
-    `https://youtube.com/@${VALID_HANDLE}`, // No prefix.
-    `https://www.youtube.com/c/${VALID_HANDLE}`, // Legacy /c/ URL.
-    `www.youtube.com/@${VALID_HANDLE}`, // No protocol.
-    `youtube.com/@${VALID_HANDLE}`, // No prefix or protocol.
-    `m.youtube.com/@${VALID_HANDLE}`, // Mobile no prefix or protocol.
-  ])('should extract handle from URL %s', (url) => {
+  it.each(VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE)('should extract handle from URL "%s"', (url) => {
     const result = getYouTubeChannelId(url);
     expectResultValue(result, VALID_HANDLE);
   });
 
-  it.each([
-    `https://www.youtube.com/channel/${VALID_CHANNEL_ID}`, // Channel ID.
-    `https://m.youtube.com/channel/${VALID_CHANNEL_ID}`, // Mobile.
-  ])('should extract channel ID from URL %s', (url) => {
-    const result = getYouTubeChannelId(url);
-    expectResultValue(result, VALID_CHANNEL_ID);
-  });
+  it.each(VALID_YOUTUBE_CHANNEL_URLS_WITH_CHANNEL_ID)(
+    'should extract channel ID from URL "%s"',
+    (url) => {
+      const result = getYouTubeChannelId(url);
+      expectResultValue(result, VALID_CHANNEL_ID);
+    }
+  );
 
-  it.each([
-    'https://www.youtube.com/watch?v=dQw4w9WgXcQ', // YouTube video URL.
-    `https://example.com/channel/${VALID_CHANNEL_ID}`, // Non-YouTube URL.
-    'foo', // Invalid URL.
-    '', // Empty string.
-  ])('should return null from URL %s', (url) => {
+  it.each([...NON_YOUTUBE_URLS, YOUTUBE_VIDEO_URL])('should return null from value "%s"', (url) => {
     const result = getYouTubeChannelId(url);
     expectResultValue(result, null);
   });
 });
 
 describe('isYouTubeChannelUrl', () => {
-  it('should return true for /channel/ URLs', () => {
-    expect(isYouTubeChannelUrl(`https://www.youtube.com/channel/${VALID_CHANNEL_ID}`)).toBe(true);
+  it.each([
+    ...VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE,
+    ...VALID_YOUTUBE_CHANNEL_URLS_WITH_CHANNEL_ID,
+  ])('should return true for URL "%s"', (url) => {
+    expect(isYouTubeChannelUrl(url)).toBe(true);
   });
 
-  it('should return true for /@handle URLs', () => {
-    expect(isYouTubeChannelUrl(`https://www.youtube.com/@${VALID_HANDLE}`)).toBe(true);
-  });
-
-  it('should return false for /c/ URLs (not yet supported)', () => {
-    expect(isYouTubeChannelUrl(`https://www.youtube.com/c/${VALID_HANDLE}`)).toBe(false);
-  });
-
-  it('should return false for unrelated YouTube URLs', () => {
-    expect(isYouTubeChannelUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(false);
-  });
-
-  it('should return false for non-YouTube URLs', () => {
-    expect(isYouTubeChannelUrl(`https://example.com/channel/${VALID_CHANNEL_ID}`)).toBe(false);
-  });
-
-  it('should return false for m.youtube.com URLs (mobile not supported)', () => {
-    expect(isYouTubeChannelUrl(`https://m.youtube.com/channel/${VALID_CHANNEL_ID}`)).toBe(false);
-  });
-
-  it('should return false for m.youtube.com handle URLs (mobile not supported)', () => {
-    expect(isYouTubeChannelUrl(`https://m.youtube.com/@${VALID_HANDLE}`)).toBe(false);
-  });
-
-  it('should handle no protocol', () => {
-    expect(isYouTubeChannelUrl(`www.youtube.com/@${VALID_HANDLE}`)).toBe(true);
-  });
-
-  it('should return false for empty string', () => {
-    expect(isYouTubeChannelUrl('')).toBe(false);
+  it.each([...NON_YOUTUBE_URLS, YOUTUBE_VIDEO_URL])('should return false for value "%s"', (url) => {
+    expect(isYouTubeChannelUrl(url)).toBe(false);
   });
 });
 
 describe('parseYouTubeChannelId', () => {
   it('should succeed for a valid channel ID', () => {
     const result = parseYouTubeChannelId(VALID_CHANNEL_ID);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.value).toBe(VALID_CHANNEL_ID);
-    }
+    expectResultValue(result, VALID_CHANNEL_ID);
   });
 
   it('should succeed for a valid handle', () => {
     const result = parseYouTubeChannelId(VALID_HANDLE);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.value).toBe(VALID_HANDLE);
-    }
+    expectResultValue(result, VALID_HANDLE);
   });
 
   it('should fail for an empty string', () => {
     const result = parseYouTubeChannelId('');
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.message).toMatch(/Invalid YouTube channel ID/);
-    }
+    expectErrorResult(result, /Invalid YouTube channel ID/);
   });
 
   it('should fail for a string longer than 128 characters', () => {
-    const longId = 'a'.repeat(129);
-    const result = parseYouTubeChannelId(longId);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.message).toMatch(/Invalid YouTube channel ID/);
-    }
+    const result = parseYouTubeChannelId('a'.repeat(129));
+    expectErrorResult(result, /Invalid YouTube channel ID/);
   });
 });

--- a/packages/shared/src/lib/youtube.shared.test.ts
+++ b/packages/shared/src/lib/youtube.shared.test.ts
@@ -11,65 +11,34 @@ const VALID_CHANNEL_ID = unwrapOrThrow<YouTubeChannelId>(
 const VALID_HANDLE = unwrapOrThrow<YouTubeChannelId>(parseYouTubeChannelId('jacobwenger8649'));
 
 describe('getYouTubeChannelId', () => {
-  it.only('should extract channel ID from /channel/ URLs', () => {
-    const url = `https://www.youtube.com/channel/${VALID_CHANNEL_ID}`;
-    const result = getYouTubeChannelId(url);
-    expectResultValue(result, VALID_CHANNEL_ID);
-  });
-
-  it('should extract channel ID from /@handle URLs', () => {
-    const url = `https://www.youtube.com/@${VALID_HANDLE}`;
+  it.each([
+    `https://www.youtube.com/@${VALID_HANDLE}`, // Handle.
+    `https://youtube.com/@${VALID_HANDLE}`, // No prefix.
+    `https://www.youtube.com/c/${VALID_HANDLE}`, // Legacy /c/ URL.
+    `www.youtube.com/@${VALID_HANDLE}`, // No protocol.
+    `youtube.com/@${VALID_HANDLE}`, // No prefix or protocol.
+    `m.youtube.com/@${VALID_HANDLE}`, // Mobile no prefix or protocol.
+  ])('should extract handle from URL %s', (url) => {
     const result = getYouTubeChannelId(url);
     expectResultValue(result, VALID_HANDLE);
   });
 
-  it('should return null for /c/ URLs', () => {
-    const url = `https://www.youtube.com/c/${VALID_HANDLE}`;
-    const result = getYouTubeChannelId(url);
-    expectResultValue(result, null);
-  });
-
-  it('should return null for unrelated YouTube URLs', () => {
-    const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'; // Not a channel URL
-    const result = getYouTubeChannelId(url);
-    expectResultValue(result, null);
-  });
-
-  it('should return null for non-YouTube URLs', () => {
-    const url = `https://example.com/channel/${VALID_CHANNEL_ID}`; // Not a YouTube URL
-    const result = getYouTubeChannelId(url);
-    expectResultValue(result, null);
-  });
-
-  it('should handle mobile m.youtube.com URLs', () => {
-    const url = `https://m.youtube.com/channel/${VALID_CHANNEL_ID}`;
+  it.each([
+    `https://www.youtube.com/channel/${VALID_CHANNEL_ID}`, // Channel ID.
+    `https://m.youtube.com/channel/${VALID_CHANNEL_ID}`, // Mobile.
+  ])('should extract channel ID from URL %s', (url) => {
     const result = getYouTubeChannelId(url);
     expectResultValue(result, VALID_CHANNEL_ID);
   });
 
-  it('should return null for m.youtube.com handle URLs (mobile not supported)', () => {
-    const url = `https://m.youtube.com/@${VALID_HANDLE}`;
+  it.each([
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ', // YouTube video URL.
+    `https://example.com/channel/${VALID_CHANNEL_ID}`, // Non-YouTube URL.
+    'foo', // Invalid URL.
+    '', // Empty string.
+  ])('should return null from URL %s', (url) => {
     const result = getYouTubeChannelId(url);
     expectResultValue(result, null);
-  });
-
-  it('should return null for empty string', () => {
-    const result = getYouTubeChannelId('');
-    expectResultValue(result, null);
-  });
-
-  it('should handle various URL formats', () => {
-    const urlsToTest = [
-      `https://youtube.com/@${VALID_HANDLE}`, // No www.
-      `youtube.com/@${VALID_HANDLE}`, // No protocol. No www.
-      `www.youtube.com/@${VALID_HANDLE}`, // No protocol.
-      `m.youtube.com/@${VALID_HANDLE}`, // Mobile.
-    ];
-
-    for (const url of urlsToTest) {
-      const result = getYouTubeChannelId(url);
-      expectResultValue(result, VALID_HANDLE);
-    }
   });
 });
 

--- a/packages/shared/src/lib/youtube.shared.test.ts
+++ b/packages/shared/src/lib/youtube.shared.test.ts
@@ -1,14 +1,18 @@
 import {expectErrorResult, expectResultValue, unwrapOrThrow} from '@shared/lib/testUtils.shared';
-import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youtube.shared';
+import {
+  getYouTubeChannelHandle,
+  getYouTubeChannelId,
+  isYouTubeChannelUrl,
+} from '@shared/lib/youtube.shared';
 
-import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
+import {parseYouTubeChannelId, parseYouTubeHandle} from '@shared/parsers/youtube.parser';
 
-import type {YouTubeChannelId} from '@shared/types/youtube.types';
+import type {YouTubeChannelId, YouTubeHandle} from '@shared/types/youtube.types';
 
 const VALID_CHANNEL_ID = unwrapOrThrow<YouTubeChannelId>(
   parseYouTubeChannelId('UCndkjnoQawp7Tjy1uNj53yQ')
 );
-const VALID_HANDLE = unwrapOrThrow<YouTubeChannelId>(parseYouTubeChannelId('jacobwenger8649'));
+const VALID_HANDLE = unwrapOrThrow<YouTubeHandle>(parseYouTubeHandle('jacobwenger8649'));
 
 const VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE = [
   `https://www.youtube.com/@${VALID_HANDLE}`, // Handle.
@@ -32,12 +36,20 @@ const NON_YOUTUBE_URLS = [
 
 const YOUTUBE_VIDEO_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
 
-describe('getYouTubeChannelId', () => {
-  it.each(VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE)('should extract handle from URL "%s"', (url) => {
-    const result = getYouTubeChannelId(url);
-    expectResultValue(result, VALID_HANDLE);
+describe('isYouTubeChannelUrl', () => {
+  it.each([
+    ...VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE,
+    ...VALID_YOUTUBE_CHANNEL_URLS_WITH_CHANNEL_ID,
+  ])('should return true for URL "%s"', (url) => {
+    expect(isYouTubeChannelUrl(url)).toBe(true);
   });
 
+  it.each([...NON_YOUTUBE_URLS, YOUTUBE_VIDEO_URL])('should return false for value "%s"', (url) => {
+    expect(isYouTubeChannelUrl(url)).toBe(false);
+  });
+});
+
+describe('getYouTubeChannelId', () => {
   it.each(VALID_YOUTUBE_CHANNEL_URLS_WITH_CHANNEL_ID)(
     'should extract channel ID from URL "%s"',
     (url) => {
@@ -52,37 +64,49 @@ describe('getYouTubeChannelId', () => {
   });
 });
 
-describe('isYouTubeChannelUrl', () => {
-  it.each([
-    ...VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE,
-    ...VALID_YOUTUBE_CHANNEL_URLS_WITH_CHANNEL_ID,
-  ])('should return true for URL "%s"', (url) => {
-    expect(isYouTubeChannelUrl(url)).toBe(true);
+describe('getYouTubeChannelHandle', () => {
+  it.each(VALID_YOUTUBE_CHANNEL_URLS_WITH_HANDLE)('should extract handle from URL "%s"', (url) => {
+    const result = getYouTubeChannelHandle(url);
+    expectResultValue(result, VALID_HANDLE);
   });
 
-  it.each([...NON_YOUTUBE_URLS, YOUTUBE_VIDEO_URL])('should return false for value "%s"', (url) => {
-    expect(isYouTubeChannelUrl(url)).toBe(false);
+  it.each([...NON_YOUTUBE_URLS, YOUTUBE_VIDEO_URL])('should return null from value "%s"', (url) => {
+    const result = getYouTubeChannelHandle(url);
+    expectResultValue(result, null);
   });
 });
 
 describe('parseYouTubeChannelId', () => {
-  it('should succeed for a valid channel ID', () => {
-    const result = parseYouTubeChannelId(VALID_CHANNEL_ID);
-    expectResultValue(result, VALID_CHANNEL_ID);
+  it.each([VALID_CHANNEL_ID])('should succeed for a valid channel ID "%s"', (id) => {
+    const result = parseYouTubeChannelId(id);
+    expectResultValue(result, id);
   });
 
-  it('should succeed for a valid handle', () => {
-    const result = parseYouTubeChannelId(VALID_HANDLE);
-    expectResultValue(result, VALID_HANDLE);
+  it.each([
+    'UCndkjnoQawp7Tjy1uNj53y', // Too short.
+    'UCndkjnoQawp7Tjy1uNj53yQQ', // Too long.
+    'ACndkjnoQawp7Tjy1uNj53yQ', // Does not start with UC.
+    'UCndkjnoQawp7Tjy1uNj53y!', // Invalid character.
+    'jacobwenger8649', // Not a channel ID (handle).
+    'a'.repeat(24), // 24 chars but does not match regex.
+    '', // Empty string.
+  ])('should fail for invalid channel ID "%s"', (id) => {
+    const result = parseYouTubeChannelId(id);
+    expectErrorResult(result, /YouTube channel ID/);
+  });
+});
+
+describe('parseYouTubeHandle', () => {
+  it.each([VALID_HANDLE])('should succeed for a valid handle "%s"', (handle) => {
+    const result = parseYouTubeHandle(handle);
+    expectResultValue(result, handle);
   });
 
-  it('should fail for an empty string', () => {
-    const result = parseYouTubeChannelId('');
-    expectErrorResult(result, /Invalid YouTube channel ID/);
-  });
-
-  it('should fail for a string longer than 128 characters', () => {
-    const result = parseYouTubeChannelId('a'.repeat(129));
-    expectErrorResult(result, /Invalid YouTube channel ID/);
+  it.each([
+    'a'.repeat(129), // Too long.
+    '', // Empty string.
+  ])('should fail for invalid handle "%s"', (handle) => {
+    const result = parseYouTubeHandle(handle);
+    expectErrorResult(result, /YouTube handle/);
   });
 });

--- a/packages/shared/src/lib/youtube.shared.test.ts
+++ b/packages/shared/src/lib/youtube.shared.test.ts
@@ -1,5 +1,5 @@
 import {expectResultValue, unwrapOrThrow} from '@shared/lib/testUtils.shared';
-import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youTube.shared';
+import {getYouTubeChannelId, isYouTubeChannelUrl} from '@shared/lib/youtube.shared';
 
 import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
 

--- a/packages/shared/src/lib/youtube.shared.ts
+++ b/packages/shared/src/lib/youtube.shared.ts
@@ -1,14 +1,14 @@
 import {makeSuccessResult} from '@shared/lib/results.shared';
 import {parseUrl} from '@shared/lib/urls.shared';
 
-import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
+import {parseYouTubeChannelId, parseYouTubeHandle} from '@shared/parsers/youtube.parser';
 
 import type {Result} from '@shared/types/results.types';
-import type {YouTubeChannelId} from '@shared/types/youtube.types';
+import type {YouTubeChannelId, YouTubeHandle} from '@shared/types/youtube.types';
 
 const YOUTUBE_CHANNEL_ID_PATH_REGEX = /^\/channel\/([a-zA-Z0-9_-]+)$/i;
-const YOUTUBE_CHANNEL_HANDLE_PATH_REGEX = /^\/@([a-zA-Z0-9_-]+)$/i;
-const YOUTUBE_CHANNEL_LEGACY_PATH_REGEX = /^\/c\/([a-zA-Z0-9_-]+)$/i;
+const YOUTUBE_CHANNEL_AT_HANDLE_PATH_REGEX = /^\/@([a-zA-Z0-9_-]+)$/i;
+const YOUTUBE_CHANNEL_C_HANDLE_PATH_REGEX = /^\/c\/([a-zA-Z0-9_-]+)$/i;
 const YOUTUBE_HOSTNAMES = [
   'youtube.com',
   'www.youtube.com',
@@ -35,9 +35,9 @@ export function isYouTubeChannelUrl(url: string): boolean {
   const normalizedHostname = normalizeYouTubeHostname(parsedUrl.hostname);
   if (!YOUTUBE_HOSTNAMES.includes(normalizedHostname)) return false;
 
-  if (YOUTUBE_CHANNEL_HANDLE_PATH_REGEX.test(parsedUrl.pathname)) return true;
   if (YOUTUBE_CHANNEL_ID_PATH_REGEX.test(parsedUrl.pathname)) return true;
-  if (YOUTUBE_CHANNEL_LEGACY_PATH_REGEX.test(parsedUrl.pathname)) return true;
+  if (YOUTUBE_CHANNEL_AT_HANDLE_PATH_REGEX.test(parsedUrl.pathname)) return true;
+  if (YOUTUBE_CHANNEL_C_HANDLE_PATH_REGEX.test(parsedUrl.pathname)) return true;
 
   return false;
 }
@@ -54,19 +54,35 @@ export function getYouTubeChannelId(url: string): Result<YouTubeChannelId | null
   const normalizedHostname = normalizeYouTubeHostname(parsedUrl.hostname);
   if (!YOUTUBE_HOSTNAMES.includes(normalizedHostname)) return makeSuccessResult(null);
 
-  const handleMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_HANDLE_PATH_REGEX);
-  if (handleMatch) {
-    return parseYouTubeChannelId(handleMatch[1]);
-  }
-
   const idMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_ID_PATH_REGEX);
   if (idMatch) {
     return parseYouTubeChannelId(idMatch[1]);
   }
 
-  const legacyMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_LEGACY_PATH_REGEX);
+  return makeSuccessResult(null);
+}
+
+/**
+ * Returns the YouTube channel handle from the provided URL. Handles many variations of YouTube
+ * URLs.
+ *
+ * If no channel handle found, returns `null`.
+ */
+export function getYouTubeChannelHandle(url: string): Result<YouTubeHandle | null> {
+  const parsedUrl = parseUrl(url);
+  if (!parsedUrl) return makeSuccessResult(null);
+
+  const normalizedHostname = normalizeYouTubeHostname(parsedUrl.hostname);
+  if (!YOUTUBE_HOSTNAMES.includes(normalizedHostname)) return makeSuccessResult(null);
+
+  const handleMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_AT_HANDLE_PATH_REGEX);
+  if (handleMatch) {
+    return parseYouTubeHandle(handleMatch[1]);
+  }
+
+  const legacyMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_C_HANDLE_PATH_REGEX);
   if (legacyMatch) {
-    return parseYouTubeChannelId(legacyMatch[1]);
+    return parseYouTubeHandle(legacyMatch[1]);
   }
 
   return makeSuccessResult(null);

--- a/packages/shared/src/lib/youtube.shared.ts
+++ b/packages/shared/src/lib/youtube.shared.ts
@@ -8,6 +8,7 @@ import type {YouTubeChannelId} from '@shared/types/youtube.types';
 
 const YOUTUBE_CHANNEL_ID_PATH_REGEX = /^\/channel\/([a-zA-Z0-9_-]+)$/i;
 const YOUTUBE_CHANNEL_HANDLE_PATH_REGEX = /^\/@([a-zA-Z0-9_-]+)$/i;
+const YOUTUBE_CHANNEL_LEGACY_PATH_REGEX = /^\/c\/([a-zA-Z0-9_-]+)$/i;
 const YOUTUBE_HOSTNAMES = [
   'youtube.com',
   'www.youtube.com',
@@ -36,6 +37,7 @@ export function isYouTubeChannelUrl(url: string): boolean {
 
   if (YOUTUBE_CHANNEL_HANDLE_PATH_REGEX.test(parsedUrl.pathname)) return true;
   if (YOUTUBE_CHANNEL_ID_PATH_REGEX.test(parsedUrl.pathname)) return true;
+  if (YOUTUBE_CHANNEL_LEGACY_PATH_REGEX.test(parsedUrl.pathname)) return true;
 
   return false;
 }
@@ -60,6 +62,11 @@ export function getYouTubeChannelId(url: string): Result<YouTubeChannelId | null
   const idMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_ID_PATH_REGEX);
   if (idMatch) {
     return parseYouTubeChannelId(idMatch[1]);
+  }
+
+  const legacyMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_LEGACY_PATH_REGEX);
+  if (legacyMatch) {
+    return parseYouTubeChannelId(legacyMatch[1]);
   }
 
   return makeSuccessResult(null);

--- a/packages/shared/src/lib/youtube.shared.ts
+++ b/packages/shared/src/lib/youtube.shared.ts
@@ -1,0 +1,66 @@
+import {makeSuccessResult} from '@shared/lib/results.shared';
+import {parseUrl} from '@shared/lib/urls.shared';
+
+import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
+
+import type {Result} from '@shared/types/results.types';
+import type {YouTubeChannelId} from '@shared/types/youtube.types';
+
+const YOUTUBE_CHANNEL_ID_PATH_REGEX = /^\/channel\/([a-zA-Z0-9_-]+)$/i;
+const YOUTUBE_CHANNEL_HANDLE_PATH_REGEX = /^\/@([a-zA-Z0-9_-]+)$/i;
+const YOUTUBE_HOSTNAMES = [
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'youtube-nocookie.com',
+  'www.youtube-nocookie.com',
+];
+
+/**
+ * Normalizes a YouTube hostname by removing any prefixes.
+ */
+function normalizeYouTubeHostname(hostname: string): string {
+  return hostname.replace(/^(www\.|m\.)/, '');
+}
+
+/**
+ * Returns `true` if the provided URL is a YouTube channel URL.  Handles many variations of YouTube
+ * URLs.
+ */
+export function isYouTubeChannelUrl(url: string): boolean {
+  const parsedUrl = parseUrl(url);
+  if (!parsedUrl) return false;
+
+  const normalizedHostname = normalizeYouTubeHostname(parsedUrl.hostname);
+  if (!YOUTUBE_HOSTNAMES.includes(normalizedHostname)) return false;
+
+  if (YOUTUBE_CHANNEL_HANDLE_PATH_REGEX.test(parsedUrl.pathname)) return true;
+  if (YOUTUBE_CHANNEL_ID_PATH_REGEX.test(parsedUrl.pathname)) return true;
+
+  return false;
+}
+
+/**
+ * Returns the YouTube channel ID from the provided URL. Handles many variations of YouTube URLs.
+ *
+ * If no channel ID found, returns `null`.
+ */
+export function getYouTubeChannelId(url: string): Result<YouTubeChannelId | null> {
+  const parsedUrl = parseUrl(url);
+  if (!parsedUrl) return makeSuccessResult(null);
+
+  const normalizedHostname = normalizeYouTubeHostname(parsedUrl.hostname);
+  if (!YOUTUBE_HOSTNAMES.includes(normalizedHostname)) return makeSuccessResult(null);
+
+  const handleMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_HANDLE_PATH_REGEX);
+  if (handleMatch) {
+    return parseYouTubeChannelId(handleMatch[1]);
+  }
+
+  const idMatch = parsedUrl.pathname.match(YOUTUBE_CHANNEL_ID_PATH_REGEX);
+  if (idMatch) {
+    return parseYouTubeChannelId(idMatch[1]);
+  }
+
+  return makeSuccessResult(null);
+}

--- a/packages/shared/src/parsers/feedSources.parser.ts
+++ b/packages/shared/src/parsers/feedSources.parser.ts
@@ -36,6 +36,7 @@ export function parseFeedSource(maybeFeedSource: unknown): Result<FeedSource> {
   if (!parsedIdResult.success) return parsedIdResult;
 
   return makeSuccessResult({
+    type: parsedFeedSourceResult.value.type,
     feedSourceId: parsedIdResult.value,
     url: parsedFeedSourceResult.value.url,
     title: parsedFeedSourceResult.value.title,
@@ -50,6 +51,7 @@ export function parseFeedSource(maybeFeedSource: unknown): Result<FeedSource> {
  */
 export function toStorageFeedSource(feedSource: FeedSource): FeedSourceFromStorage {
   return {
+    type: feedSource.type,
     feedSourceId: feedSource.feedSourceId,
     url: feedSource.url,
     title: feedSource.title,

--- a/packages/shared/src/parsers/youtube.parser.ts
+++ b/packages/shared/src/parsers/youtube.parser.ts
@@ -2,6 +2,7 @@ import {prefixErrorResult} from '@shared/lib/errorUtils.shared';
 import {parseZodResult} from '@shared/lib/parser.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
 
+import type {Result} from '@shared/types/results.types';
 import type {YouTubeChannelId} from '@shared/types/youtube.types';
 import {YouTubeChannelIdSchema} from '@shared/types/youtube.types';
 

--- a/packages/shared/src/parsers/youtube.parser.ts
+++ b/packages/shared/src/parsers/youtube.parser.ts
@@ -3,8 +3,8 @@ import {parseZodResult} from '@shared/lib/parser.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
 
 import type {Result} from '@shared/types/results.types';
-import type {YouTubeChannelId} from '@shared/types/youtube.types';
-import {YouTubeChannelIdSchema} from '@shared/types/youtube.types';
+import type {YouTubeChannelId, YouTubeHandle} from '@shared/types/youtube.types';
+import {YouTubeChannelIdSchema, YouTubeHandleSchema} from '@shared/types/youtube.types';
 
 /**
  * Parses a {@link YouTubeChannelId} from a plain string. Returns an `ErrorResult` if the string is
@@ -16,4 +16,16 @@ export function parseYouTubeChannelId(maybeYouTubeChannelId: string): Result<You
     return prefixErrorResult(parsedResult, 'Invalid YouTube channel ID');
   }
   return makeSuccessResult(parsedResult.value as YouTubeChannelId);
+}
+
+/**
+ * Parses a {@link YouTubeHandle} from a plain string. Returns an `ErrorResult` if the string is not
+ * valid.
+ */
+export function parseYouTubeHandle(maybeYouTubeHandle: string): Result<YouTubeHandle> {
+  const parsedResult = parseZodResult(YouTubeHandleSchema, maybeYouTubeHandle);
+  if (!parsedResult.success) {
+    return prefixErrorResult(parsedResult, 'Invalid YouTube handle');
+  }
+  return makeSuccessResult(parsedResult.value as YouTubeHandle);
 }

--- a/packages/shared/src/parsers/youtube.parser.ts
+++ b/packages/shared/src/parsers/youtube.parser.ts
@@ -1,0 +1,18 @@
+import {prefixErrorResult} from '@shared/lib/errorUtils.shared';
+import {parseZodResult} from '@shared/lib/parser.shared';
+import {makeSuccessResult} from '@shared/lib/results.shared';
+
+import type {YouTubeChannelId} from '@shared/types/youtube.types';
+import {YouTubeChannelIdSchema} from '@shared/types/youtube.types';
+
+/**
+ * Parses a {@link YouTubeChannelId} from a plain string. Returns an `ErrorResult` if the string is
+ * not valid.
+ */
+export function parseYouTubeChannelId(maybeYouTubeChannelId: string): Result<YouTubeChannelId> {
+  const parsedResult = parseZodResult(YouTubeChannelIdSchema, maybeYouTubeChannelId);
+  if (!parsedResult.success) {
+    return prefixErrorResult(parsedResult, 'Invalid YouTube channel ID');
+  }
+  return makeSuccessResult(parsedResult.value as YouTubeChannelId);
+}

--- a/packages/shared/src/types/youtube.types.ts
+++ b/packages/shared/src/types/youtube.types.ts
@@ -8,4 +8,19 @@ export type YouTubeChannelId = string & {readonly __brand: 'YouTubeChannelId'};
 /**
  * A Zod schema for a {@link YouTubeChannelId}.
  */
-export const YouTubeChannelIdSchema = z.string().min(1).max(128);
+export const YouTubeChannelIdSchema = z
+  .string()
+  .length(24, {message: 'YouTube channel ID must be 24 characters long'})
+  .regex(/^UC[A-Za-z0-9_-]{22}$/, {
+    message: 'YouTube channel ID must start with "UC" followed by 22 letters, digits, "_" or "-"',
+  });
+
+/**
+ * Strongly-typed identifier for a YouTube handle. Prefer this over plain strings.
+ */
+export type YouTubeHandle = string & {readonly __brand: 'YouTubeHandle'};
+
+/**
+ * A Zod schema for a {@link YouTubeHandle}.
+ */
+export const YouTubeHandleSchema = z.string().min(1).max(128);

--- a/packages/shared/src/types/youtube.types.ts
+++ b/packages/shared/src/types/youtube.types.ts
@@ -1,0 +1,11 @@
+import {z} from 'zod';
+
+/**
+ * Strongly-typed identifier for a YouTube channel. Prefer this over plain strings.
+ */
+export type YouTubeChannelId = string & {readonly __brand: 'YouTubeChannelId'};
+
+/**
+ * A Zod schema for a {@link YouTubeChannelId}.
+ */
+export const YouTubeChannelIdSchema = z.string().min(1).max(128);

--- a/packages/sharedClient/src/services/firebase.client.ts
+++ b/packages/sharedClient/src/services/firebase.client.ts
@@ -2,8 +2,8 @@ import type {FirebaseApp} from 'firebase/app';
 import {initializeApp} from 'firebase/app';
 import type {Auth} from 'firebase/auth';
 import {connectAuthEmulator, getAuth} from 'firebase/auth';
-import type {Firestore} from 'firebase/firestore';
-import {connectFirestoreEmulator, getFirestore} from 'firebase/firestore';
+import type {FieldValue, Firestore} from 'firebase/firestore';
+import {connectFirestoreEmulator, getFirestore, serverTimestamp} from 'firebase/firestore';
 import type {Functions} from 'firebase/functions';
 import {connectFunctionsEmulator, getFunctions} from 'firebase/functions';
 import type {FirebaseStorage} from 'firebase/storage';
@@ -118,4 +118,4 @@ export const firebaseService = new ClientFirebaseService({
   isEmulatorEnabled: getIsFirebaseEmulatorEnabled(),
 });
 
-// export const clientTimestampSupplier = (): FieldValue => serverTimestamp();
+export const clientTimestampSupplier = (): FieldValue => serverTimestamp();

--- a/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
+++ b/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
@@ -8,6 +8,7 @@ import {asyncTry, prefixErrorResult, prefixResultIfError} from '@shared/lib/erro
 import {makeYouTubeFeedSource} from '@shared/lib/feedSources.shared';
 import {withFirestoreTimestamps} from '@shared/lib/parser.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
+import {getYouTubeChannelId} from '@shared/lib/youtube.shared';
 
 import {
   parseUserFeedSubscription,
@@ -95,9 +96,17 @@ export class ClientUserFeedSubscriptionsService {
    * Subscribes the account to the YouTube channel. A new feed source is created if one does not
    * already exist.
    */
-  public async subscribeToYouTubeChannel(url: URL): AsyncResult<UserFeedSubscriptionId> {
+  public async subscribeToYouTubeChannel(url: URL): AsyncResult<UserFeedSubscription> {
+    const channelIdResult = getYouTubeChannelId(url.href);
+    if (!channelIdResult.success) {
+      return prefixErrorResult(channelIdResult, 'URL is not a valid YouTube channel URL');
+    }
+
+    const channelId = channelIdResult.value;
+
     const feedSource = makeYouTubeFeedSource({
-      url: url.href,
+      // TODO: Switch to `channelId`.
+      url: `https://www.youtube.com/channel/${channelId}`,
       title: 'YouTube Channel',
     });
 

--- a/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
+++ b/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
@@ -98,6 +98,10 @@ export class ClientUserFeedSubscriptionsService {
    */
   public async subscribeToYouTubeChannel(url: string): AsyncResult<UserFeedSubscription> {
     const channelIdResult = getYouTubeChannelId(url);
+
+    // TODO: Also support channel handles.
+    // const channelHandleResult = getYouTubeChannelHandle(url);
+
     if (!channelIdResult.success) {
       return prefixErrorResult(channelIdResult, 'Failed to parse YouTube channel URL');
     }

--- a/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
+++ b/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
@@ -96,8 +96,8 @@ export class ClientUserFeedSubscriptionsService {
    * Subscribes the account to the YouTube channel. A new feed source is created if one does not
    * already exist.
    */
-  public async subscribeToYouTubeChannel(url: URL): AsyncResult<UserFeedSubscription> {
-    const channelIdResult = getYouTubeChannelId(url.href);
+  public async subscribeToYouTubeChannel(url: string): AsyncResult<UserFeedSubscription> {
+    const channelIdResult = getYouTubeChannelId(url);
     if (!channelIdResult.success) {
       return prefixErrorResult(channelIdResult, 'Failed to parse YouTube channel URL');
     }

--- a/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
+++ b/packages/sharedClient/src/services/userFeedSubscriptions.client.ts
@@ -133,7 +133,18 @@ export class ClientUserFeedSubscriptionsService {
   }): AsyncResult<UserFeedSubscription> {
     const {feedSource, accountId} = args;
 
-    // TODO: Validate a feed subscription does not already exist.
+    // Check if a feed subscription already exists for this feed source.
+    const existingSubscriptionsResult =
+      await this.userFeedSubscriptionsCollectionService.fetchFirstQueryDoc([
+        where('accountId', '==', accountId),
+        where('feedSourceId', '==', feedSource.feedSourceId),
+      ]);
+    if (!existingSubscriptionsResult.success) return existingSubscriptionsResult;
+
+    const existingSubscription = existingSubscriptionsResult.value;
+    if (existingSubscription) {
+      return makeErrorResult(new Error('Feed subscription already exists'));
+    }
 
     // Make a new user feed subscription object locally.
     const userFeedSubscriptionResult = makeUserFeedSubscription({feedSource, accountId});

--- a/packages/sharedServer/src/lib/xkcd.server.ts
+++ b/packages/sharedServer/src/lib/xkcd.server.ts
@@ -6,6 +6,7 @@ import {logger} from '@shared/services/logger.shared';
 import {prefixError, upgradeUnknownError} from '@shared/lib/errorUtils.shared';
 import {requestGet} from '@shared/lib/requests.shared';
 import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
+import {parseUrl} from '@shared/lib/urls.shared';
 
 import type {AsyncResult, Result} from '@shared/types/results.types';
 
@@ -14,7 +15,9 @@ function makeAbsoluteXkcdUrl(relativeUrl: string, feedItemUrl: string): string {
   if (relativeUrl.startsWith('//')) {
     absoluteUrl = `https:${relativeUrl}`;
   } else if (relativeUrl.startsWith('/')) {
-    const {origin} = new URL(feedItemUrl);
+    const parsedUrl = parseUrl(feedItemUrl);
+    if (!parsedUrl) return relativeUrl;
+    const {origin} = parsedUrl;
     absoluteUrl = `${origin}${relativeUrl}`;
   }
 
@@ -31,7 +34,11 @@ export function makeExplainXkcdUrl(comicId: number): string {
 export function parseXkcdComicIdFromUrl(url: string): Result<number> {
   // eslint-disable-next-line no-restricted-syntax
   try {
-    const {hostname, pathname} = new URL(url);
+    const parsedUrl = parseUrl(url);
+    if (!parsedUrl) {
+      return makeErrorResult(new Error('Failed to parse XKCD URL'));
+    }
+    const {hostname, pathname} = parsedUrl;
     if (!/(^|\.)xkcd\.com$/.test(hostname)) {
       return makeErrorResult(new Error('URL host is not xkcd.com'));
     }

--- a/packages/sharedServer/src/services/feedSources.server.ts
+++ b/packages/sharedServer/src/services/feedSources.server.ts
@@ -61,6 +61,7 @@ export class ServerFeedSourcesService {
     // Create the new feed source in Firestore.
     const createResult = await this.feedSourcesCollectionService.setDoc(
       newFeedSource.feedSourceId,
+      // TODO: Fix this unsafe type cast.
       withFirestoreTimestamps(newFeedSource, serverTimestampSupplier) as WithFieldValue<FeedSource>
     );
     if (!createResult.success) {

--- a/packages/sharedServer/src/services/feedSources.server.ts
+++ b/packages/sharedServer/src/services/feedSources.server.ts
@@ -1,6 +1,7 @@
 import type {WithFieldValue} from 'firebase-admin/firestore';
 
 import {prefixErrorResult, prefixResultIfError} from '@shared/lib/errorUtils.shared';
+import {makeRssFeedSource} from '@shared/lib/feedSources.shared';
 import {withFirestoreTimestamps} from '@shared/lib/parser.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
 
@@ -9,7 +10,6 @@ import type {
   FeedSourceFromStorage,
   FeedSourceId,
 } from '@shared/types/feedSources.types';
-import {makeFeedSource} from '@shared/types/feedSources.types';
 import type {AsyncResult} from '@shared/types/results.types';
 
 import {serverTimestampSupplier} from '@sharedServer/services/firebase.server';
@@ -49,21 +49,19 @@ export class ServerFeedSourcesService {
    * Adds a new feed document to Firestore. To check if a feed source with the same URL already
    * exists, use {@link fetchByUrlOrCreate}.
    */
-  public async create(
-    feedDetails: Omit<FeedSource, 'feedSourceId' | 'createdTime' | 'lastUpdatedTime'>
+  public async createRssFeedSource(
+    feedDetails: Omit<FeedSource, 'type' | 'feedSourceId' | 'createdTime' | 'lastUpdatedTime'>
   ): AsyncResult<FeedSource> {
     // Create the new feed source in memory.
-    const makeFeedSourceResult = makeFeedSource({
+    const newFeedSource = makeRssFeedSource({
       url: feedDetails.url,
       title: feedDetails.title,
     });
-    if (!makeFeedSourceResult.success) return makeFeedSourceResult;
-    const newFeedSource = makeFeedSourceResult.value;
 
     // Create the new feed source in Firestore.
     const createResult = await this.feedSourcesCollectionService.setDoc(
       newFeedSource.feedSourceId,
-      withFirestoreTimestamps(newFeedSource, serverTimestampSupplier)
+      withFirestoreTimestamps(newFeedSource, serverTimestampSupplier) as WithFieldValue<FeedSource>
     );
     if (!createResult.success) {
       return prefixErrorResult(createResult, 'Error adding feed source to Firestore');
@@ -89,7 +87,7 @@ export class ServerFeedSourcesService {
     }
 
     // Otherwise create a new feed source.
-    return await this.create({
+    return await this.createRssFeedSource({
       url,
       title: feedSourceDetails.title ?? url,
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for subscribing to YouTube channels, including a new quick-add button for personal YouTube channels.
  - Introduced utilities, types, and validation for handling YouTube channel URLs, IDs, and handles.
  - Added new test utilities and comprehensive tests for YouTube channel parsing.

- **Bug Fixes**
  - Improved URL validation and error handling for feed and XKCD URLs.

- **Refactor**
  - Refactored feed source types to use a discriminated union for RSS and YouTube sources.
  - Updated service methods and parsers to align with the new feed source structure.

- **Chores**
  - Enhanced ESLint rules to restrict test utility imports to test files only.
  - Updated Firestore timestamp handling and related utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->