### PR TITLE
Made storage file for experiment types

### DIFF
--- a/packages/functions/src/lib/initServices.func.ts
+++ b/packages/functions/src/lib/initServices.func.ts
@@ -16,10 +16,7 @@ import {makeSuccessResult} from '@shared/lib/results.shared';
 import {parseAccount, parseAccountId} from '@shared/parsers/accounts.parser';
 import {parseAccountSettings} from '@shared/parsers/accountSettings.parser';
 import {parseEventId, parseEventLogItem} from '@shared/parsers/eventLog.parser';
-import {
-  parseAccountExperimentsState,
-  toStorageAccountExperimentsState,
-} from '@shared/parsers/experiments.parser';
+import {parseAccountExperimentsState} from '@shared/parsers/experiments.parser';
 import {parseFeedItem, parseFeedItemId, toStorageFeedItem} from '@shared/parsers/feedItems.parser';
 import {
   parseUserFeedSubscription,
@@ -34,6 +31,7 @@ import type {RssFeedProvider} from '@shared/types/rss.types';
 import {toStorageAccount} from '@shared/storage/accounts.storage';
 import {toStorageAccountSettings} from '@shared/storage/accountSettings.storage';
 import {toStorageEventLogItem} from '@shared/storage/eventLog.storage';
+import {toStorageAccountExperimentsState} from '@shared/storage/experiments.storage';
 
 import {ServerAccountsService} from '@sharedServer/services/accounts.server';
 import {ServerAccountSettingsService} from '@sharedServer/services/accountSettings.server';

--- a/packages/shared/src/lib/parser.shared.ts
+++ b/packages/shared/src/lib/parser.shared.ts
@@ -2,7 +2,6 @@ import type {ZodSchema} from 'zod';
 
 import {isDate} from '@shared/lib/datetime.shared';
 import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
-import {omitUndefined} from '@shared/lib/utils.shared';
 
 import type {Result} from '@shared/types/results.types';
 import type {BaseStoreItem, Supplier} from '@shared/types/utils.types';
@@ -59,11 +58,11 @@ export function withFirestoreTimestamps<ItemData extends BaseStoreItem, Timestam
   createdTime: Timestamp;
   lastUpdatedTime: Timestamp;
 } {
-  return omitUndefined({
+  return {
     ...item,
     createdTime: timestampFactory(),
     lastUpdatedTime: timestampFactory(),
-  });
+  };
 }
 
 /**
@@ -82,10 +81,10 @@ export function withFirestoreTimestampsExtended<
   createdTime: Timestamp;
   lastUpdatedTime: Timestamp;
 } {
-  return omitUndefined({
+  return {
     ...item,
     createdTime: timestampFactory(),
     lastUpdatedTime: timestampFactory(),
     [additionalTimestampField]: timestampFactory(),
-  });
+  };
 }

--- a/packages/shared/src/parsers/experiments.parser.ts
+++ b/packages/shared/src/parsers/experiments.parser.ts
@@ -1,178 +1,42 @@
-import {logger} from '@shared/services/logger.shared';
-
 import {prefixErrorResult} from '@shared/lib/errorUtils.shared';
 import {parseZodResult} from '@shared/lib/parser.shared';
-import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
-import {omitUndefined, safeAssertNever} from '@shared/lib/utils.shared';
 
-import {parseAccountId} from '@shared/parsers/accounts.parser';
-
-import type {
-  AccountExperimentsState,
-  BooleanExperimentDefinition,
-  ExperimentDefinition,
-  StringExperimentDefinition,
-} from '@shared/types/experiments.types';
-import {ExperimentType} from '@shared/types/experiments.types';
+import type {AccountExperimentsState, ExperimentDefinition} from '@shared/types/experiments.types';
 import type {Result} from '@shared/types/results.types';
 
-import {
-  AccountExperimentsStateSchema,
-  BaseExperimentDefinitionSchema,
-  BooleanExperimentDefinitionSchema,
-  StringExperimentDefinitionSchema,
-} from '@shared/schemas/experiments.schema';
 import type {
   AccountExperimentsStateFromStorage,
-  BaseExperimentDefinitionFromStorage,
-  BooleanExperimentDefinitionFromStorage,
   ExperimentDefinitionFromStorage,
-  StringExperimentDefinitionFromStorage,
 } from '@shared/schemas/experiments.schema';
+import {
+  AccountExperimentsStateSchema,
+  ExperimentDefinitionSchema,
+} from '@shared/schemas/experiments.schema';
+import {
+  fromStorageAccountExperimentsState,
+  fromStorageExperimentDefinition,
+} from '@shared/storage/experiments.storage';
 
 /**
- * Parses an {@link ExperimentDefinition} from an unknown value. Returns an `ErrorResult` if the
- * value is not valid.
+ * Attempts to parse an unknown value into an {@link ExperimentDefinition}.
  */
 export function parseExperimentDefinition(
   maybeExperimentDefinition: unknown
 ): Result<ExperimentDefinition> {
-  const parsedExpDefinitionResult = parseZodResult<BaseExperimentDefinitionFromStorage>(
-    BaseExperimentDefinitionSchema,
+  const parsedExpDefinitionResult = parseZodResult<ExperimentDefinitionFromStorage>(
+    ExperimentDefinitionSchema,
     maybeExperimentDefinition
   );
   if (!parsedExpDefinitionResult.success) {
     return prefixErrorResult(parsedExpDefinitionResult, 'Invalid experiment definition');
   }
 
-  const parsedExpDefinition = parsedExpDefinitionResult.value;
-  switch (parsedExpDefinition.experimentType) {
-    case ExperimentType.Boolean:
-      return parseBooleanExperimentDefinition({maybeExperimentDefinition});
-    case ExperimentType.String:
-      return parseStringExperimentDefinition({maybeExperimentDefinition});
-    default:
-      safeAssertNever(parsedExpDefinition.experimentType);
-      return makeErrorResult(
-        new Error(`Unknown experiment type: ${parsedExpDefinition.experimentType}`)
-      );
-  }
-}
-
-function parseBooleanExperimentDefinition(args: {
-  readonly maybeExperimentDefinition: unknown;
-}): Result<BooleanExperimentDefinition> {
-  const {maybeExperimentDefinition} = args;
-
-  const parsedExperimentResult = parseZodResult<BooleanExperimentDefinitionFromStorage>(
-    BooleanExperimentDefinitionSchema,
-    maybeExperimentDefinition
-  );
-  if (!parsedExperimentResult.success) {
-    return prefixErrorResult(parsedExperimentResult, 'Invalid boolean experiment definition');
-  }
-  const storageBooleanExperiment = parsedExperimentResult.value;
-
-  return makeSuccessResult(
-    omitUndefined({
-      experimentType: ExperimentType.Boolean,
-      defaultIsEnabled: storageBooleanExperiment.defaultIsEnabled,
-      experimentId: storageBooleanExperiment.experimentId,
-      environments: storageBooleanExperiment.environments,
-      visibility: storageBooleanExperiment.visibility,
-      title: storageBooleanExperiment.title,
-      description: storageBooleanExperiment.description,
-    })
-  );
-}
-
-function parseStringExperimentDefinition(args: {
-  readonly maybeExperimentDefinition: unknown;
-}): Result<StringExperimentDefinition> {
-  const {maybeExperimentDefinition} = args;
-
-  const parsedExperimentResult = parseZodResult<StringExperimentDefinitionFromStorage>(
-    StringExperimentDefinitionSchema,
-    maybeExperimentDefinition
-  );
-  if (!parsedExperimentResult.success) {
-    return prefixErrorResult(parsedExperimentResult, 'Invalid string experiment definition');
-  }
-  const storageStringExperiment = parsedExperimentResult.value;
-
-  return makeSuccessResult(
-    omitUndefined({
-      experimentType: ExperimentType.String,
-      defaultIsEnabled: storageStringExperiment.defaultIsEnabled,
-      defaultValue: storageStringExperiment.defaultValue,
-      experimentId: storageStringExperiment.experimentId,
-      environments: storageStringExperiment.environments,
-      visibility: storageStringExperiment.visibility,
-      title: storageStringExperiment.title,
-      description: storageStringExperiment.description,
-    })
-  );
+  const experimentDefinitionFromStorage = parsedExpDefinitionResult.value;
+  return fromStorageExperimentDefinition(experimentDefinitionFromStorage);
 }
 
 /**
- * Converts an {@link ExperimentDefinition} to an {@link ExperimentDefinitionFromStorage} object
- * that can be persisted to Firestore.
- */
-export function toStorageExperimentDefinition(
-  experimentDefinition: ExperimentDefinition
-): ExperimentDefinitionFromStorage {
-  switch (experimentDefinition.experimentType) {
-    case ExperimentType.Boolean:
-      return toStorageBooleanExperimentDefinition(experimentDefinition);
-    case ExperimentType.String:
-      return toStorageStringExperimentDefinition(experimentDefinition);
-    default:
-      safeAssertNever(experimentDefinition);
-      logger.error(new Error('Unknown experiment type'), {experimentDefinition});
-      return toStorageBooleanExperimentDefinition(experimentDefinition);
-  }
-}
-
-/**
- * Converts a {@link BooleanExperimentDefinition} to a {@link BooleanExperimentDefinitionFromStorage} object that can be
- * persisted to Firestore.
- */
-function toStorageBooleanExperimentDefinition(
-  experimentDefinition: BooleanExperimentDefinition
-): BooleanExperimentDefinitionFromStorage {
-  return omitUndefined({
-    experimentId: experimentDefinition.experimentId,
-    experimentType: ExperimentType.Boolean,
-    defaultIsEnabled: experimentDefinition.defaultIsEnabled,
-    environments: [...experimentDefinition.environments],
-    visibility: experimentDefinition.visibility,
-    title: experimentDefinition.title,
-    description: experimentDefinition.description,
-  });
-}
-
-/**
- * Converts an {@link StringExperimentDefinition} to a {@link StringExperimentDefinitionFromStorage} object that can be
- * persisted to Firestore.
- */
-function toStorageStringExperimentDefinition(
-  experiment: StringExperimentDefinition
-): StringExperimentDefinitionFromStorage {
-  return omitUndefined({
-    experimentId: experiment.experimentId,
-    experimentType: ExperimentType.String,
-    environments: [...experiment.environments],
-    visibility: experiment.visibility,
-    title: experiment.title,
-    description: experiment.description,
-    defaultIsEnabled: experiment.defaultIsEnabled,
-    defaultValue: experiment.defaultValue,
-  });
-}
-
-/**
- * Parses an {@link AccountExperimentsState} from an unknown value. Returns an `ErrorResult` if the
- * value is not valid.
+ * Attempts to parse an unknown value into an {@link AccountExperimentsState}.
  */
 export function parseAccountExperimentsState(
   maybeAccountExperimentsState: unknown
@@ -187,34 +51,6 @@ export function parseAccountExperimentsState(
     return prefixErrorResult(parsedAccountExperimentsStateResult, message);
   }
 
-  const parsedAccountExperimentsState = parsedAccountExperimentsStateResult.value;
-
-  const parsedAccountId = parseAccountId(parsedAccountExperimentsState.accountId);
-  if (!parsedAccountId.success) {
-    return prefixErrorResult(parsedAccountId, 'Invalid account ID');
-  }
-
-  return makeSuccessResult({
-    accountId: parsedAccountId.value,
-    accountVisibility: parsedAccountExperimentsState.accountVisibility,
-    experimentOverrides: parsedAccountExperimentsState.experimentOverrides,
-    createdTime: parsedAccountExperimentsState.createdTime,
-    lastUpdatedTime: parsedAccountExperimentsState.lastUpdatedTime,
-  });
-}
-
-/**
- * Converts an {@link AccountExperimentsState} to an {@link AccountExperimentsStateFromStorage}
- * object that can be persisted to Firestore.
- */
-export function toStorageAccountExperimentsState(
-  state: AccountExperimentsState
-): AccountExperimentsStateFromStorage {
-  return omitUndefined({
-    accountId: state.accountId,
-    accountVisibility: state.accountVisibility,
-    experimentOverrides: state.experimentOverrides,
-    createdTime: state.createdTime,
-    lastUpdatedTime: state.lastUpdatedTime,
-  });
+  const accountExperimentsStateFromStorage = parsedAccountExperimentsStateResult.value;
+  return fromStorageAccountExperimentsState(accountExperimentsStateFromStorage);
 }

--- a/packages/shared/src/parsers/feedItems.parser.ts
+++ b/packages/shared/src/parsers/feedItems.parser.ts
@@ -3,7 +3,6 @@ import {logger} from '@shared/services/logger.shared';
 import {prefixErrorResult} from '@shared/lib/errorUtils.shared';
 import {parseStorageTimestamp, parseZodResult} from '@shared/lib/parser.shared';
 import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
-import {omitUndefined} from '@shared/lib/utils.shared';
 
 import {parseAccountId} from '@shared/parsers/accounts.parser';
 import {parseFeedSource, parseIntervalFeedSource} from '@shared/parsers/feedSources.parser';
@@ -223,24 +222,22 @@ export function parseFeedItemWithUrl(args: {
   if (!parseFeedSourceResult.success) return parseFeedSourceResult;
   const parsedFeedSource = parseFeedSourceResult.value;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedItemType,
-      feedSource: parsedFeedSource,
-      accountId,
-      importState,
-      feedItemId,
-      url: storageBaseFeedItem.url,
-      title: storageBaseFeedItem.title,
-      description: storageBaseFeedItem.description,
-      outgoingLinks: storageBaseFeedItem.outgoingLinks,
-      summary: storageBaseFeedItem.summary,
-      triageStatus: storageBaseFeedItem.triageStatus,
-      tagIds: storageBaseFeedItem.tagIds,
-      createdTime: parseStorageTimestamp(storageBaseFeedItem.createdTime),
-      lastUpdatedTime: parseStorageTimestamp(storageBaseFeedItem.lastUpdatedTime),
-    })
-  );
+  return makeSuccessResult({
+    feedItemType,
+    feedSource: parsedFeedSource,
+    accountId,
+    importState,
+    feedItemId,
+    url: storageBaseFeedItem.url,
+    title: storageBaseFeedItem.title,
+    description: storageBaseFeedItem.description,
+    outgoingLinks: storageBaseFeedItem.outgoingLinks,
+    summary: storageBaseFeedItem.summary,
+    triageStatus: storageBaseFeedItem.triageStatus,
+    tagIds: storageBaseFeedItem.tagIds,
+    createdTime: parseStorageTimestamp(storageBaseFeedItem.createdTime),
+    lastUpdatedTime: parseStorageTimestamp(storageBaseFeedItem.lastUpdatedTime),
+  });
 }
 
 export function parseXkcdFeedItem(args: {
@@ -261,25 +258,23 @@ export function parseXkcdFeedItem(args: {
   if (!parsedFeedSourceResult.success) return parsedFeedSourceResult;
   const parsedFeedSource = parsedFeedSourceResult.value;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedItemType: FeedItemType.Xkcd,
-      xkcd: parsedXkcdFeedItemResult.value.xkcd,
-      feedSource: parsedFeedSource,
-      accountId,
-      importState,
-      feedItemId,
-      url: storageXkcdFeedItem.url,
-      title: storageXkcdFeedItem.title,
-      description: storageXkcdFeedItem.description,
-      outgoingLinks: storageXkcdFeedItem.outgoingLinks,
-      summary: storageXkcdFeedItem.summary,
-      triageStatus: storageXkcdFeedItem.triageStatus,
-      tagIds: storageXkcdFeedItem.tagIds,
-      createdTime: parseStorageTimestamp(storageXkcdFeedItem.createdTime),
-      lastUpdatedTime: parseStorageTimestamp(storageXkcdFeedItem.lastUpdatedTime),
-    })
-  );
+  return makeSuccessResult({
+    feedItemType: FeedItemType.Xkcd,
+    xkcd: parsedXkcdFeedItemResult.value.xkcd,
+    feedSource: parsedFeedSource,
+    accountId,
+    importState,
+    feedItemId,
+    url: storageXkcdFeedItem.url,
+    title: storageXkcdFeedItem.title,
+    description: storageXkcdFeedItem.description,
+    outgoingLinks: storageXkcdFeedItem.outgoingLinks,
+    summary: storageXkcdFeedItem.summary,
+    triageStatus: storageXkcdFeedItem.triageStatus,
+    tagIds: storageXkcdFeedItem.tagIds,
+    createdTime: parseStorageTimestamp(storageXkcdFeedItem.createdTime),
+    lastUpdatedTime: parseStorageTimestamp(storageXkcdFeedItem.lastUpdatedTime),
+  });
 }
 
 export function parseIntervalFeedItem(args: {
@@ -300,20 +295,18 @@ export function parseIntervalFeedItem(args: {
   if (!parsedFeedSourceResult.success) return parsedFeedSourceResult;
   const parsedFeedSource = parsedFeedSourceResult.value;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedItemType: FeedItemType.Interval,
-      feedSource: parsedFeedSource,
-      accountId,
-      importState,
-      feedItemId,
-      title: storageIntervalFeedItem.title,
-      triageStatus: storageIntervalFeedItem.triageStatus,
-      tagIds: storageIntervalFeedItem.tagIds,
-      createdTime: parseStorageTimestamp(storageIntervalFeedItem.createdTime),
-      lastUpdatedTime: parseStorageTimestamp(storageIntervalFeedItem.lastUpdatedTime),
-    })
-  );
+  return makeSuccessResult({
+    feedItemType: FeedItemType.Interval,
+    feedSource: parsedFeedSource,
+    accountId,
+    importState,
+    feedItemId,
+    title: storageIntervalFeedItem.title,
+    triageStatus: storageIntervalFeedItem.triageStatus,
+    tagIds: storageIntervalFeedItem.tagIds,
+    createdTime: parseStorageTimestamp(storageIntervalFeedItem.createdTime),
+    lastUpdatedTime: parseStorageTimestamp(storageIntervalFeedItem.lastUpdatedTime),
+  });
 }
 
 /**
@@ -345,7 +338,7 @@ export function toStorageFeedItem(feedItem: FeedItem): FeedItemFromStorage {
 function toStorageBaseFeedItem(
   feedItem: Exclude<FeedItem, XkcdFeedItem | IntervalFeedItem>
 ): BaseFeedItemWithUrlFromStorage {
-  return omitUndefined({
+  return {
     feedItemId: feedItem.feedItemId,
     feedItemType: feedItem.feedItemType,
     feedSource: feedItem.feedSource,
@@ -360,7 +353,7 @@ function toStorageBaseFeedItem(
     tagIds: feedItem.tagIds,
     createdTime: feedItem.createdTime,
     lastUpdatedTime: feedItem.lastUpdatedTime,
-  });
+  };
 }
 
 /**
@@ -368,7 +361,7 @@ function toStorageBaseFeedItem(
  * persisted to Firestore.
  */
 function toStorageXkcdFeedItem(feedItem: XkcdFeedItem): XkcdFeedItemFromStorage {
-  return omitUndefined({
+  return {
     feedItemId: feedItem.feedItemId,
     feedItemType: feedItem.feedItemType,
     feedSource: feedItem.feedSource,
@@ -384,7 +377,7 @@ function toStorageXkcdFeedItem(feedItem: XkcdFeedItem): XkcdFeedItemFromStorage 
     createdTime: feedItem.createdTime,
     lastUpdatedTime: feedItem.lastUpdatedTime,
     xkcd: feedItem.xkcd,
-  });
+  };
 }
 
 /**
@@ -392,7 +385,7 @@ function toStorageXkcdFeedItem(feedItem: XkcdFeedItem): XkcdFeedItemFromStorage 
  * persisted to Firestore.
  */
 function toStorageIntervalFeedItem(feedItem: IntervalFeedItem): IntervalFeedItemFromStorage {
-  return omitUndefined({
+  return {
     feedItemId: feedItem.feedItemId,
     feedItemType: feedItem.feedItemType,
     feedSource: feedItem.feedSource,
@@ -403,5 +396,5 @@ function toStorageIntervalFeedItem(feedItem: IntervalFeedItem): IntervalFeedItem
     tagIds: feedItem.tagIds,
     createdTime: feedItem.createdTime,
     lastUpdatedTime: feedItem.lastUpdatedTime,
-  });
+  };
 }

--- a/packages/shared/src/parsers/feedSources.parser.ts
+++ b/packages/shared/src/parsers/feedSources.parser.ts
@@ -6,7 +6,6 @@ import {
 } from '@shared/lib/feedSources.shared';
 import {parseZodResult} from '@shared/lib/parser.shared';
 import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
-import {omitUndefined} from '@shared/lib/utils.shared';
 
 import {parseUserFeedSubscriptionId} from '@shared/parsers/userFeedSubscriptions.parser';
 import {parseYouTubeChannelId} from '@shared/parsers/youtube.parser';
@@ -68,14 +67,12 @@ function parseRssFeedSource(maybeRssFeedSource: unknown): Result<RssFeedSource> 
   );
   if (!parsedFeedSubIdResult.success) return parsedFeedSubIdResult;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedSourceType: FeedSourceType.RSS,
-      userFeedSubscriptionId: parsedFeedSubIdResult.value,
-      url: parsedRssFeedSource.url,
-      title: parsedRssFeedSource.title,
-    })
-  );
+  return makeSuccessResult({
+    feedSourceType: FeedSourceType.RSS,
+    userFeedSubscriptionId: parsedFeedSubIdResult.value,
+    url: parsedRssFeedSource.url,
+    title: parsedRssFeedSource.title,
+  });
 }
 
 function parseYouTubeChannelFeedSource(
@@ -98,13 +95,11 @@ function parseYouTubeChannelFeedSource(
   const parsedChannelIdResult = parseYouTubeChannelId(parsedYouTubeChannelFeedSource.channelId);
   if (!parsedChannelIdResult.success) return parsedChannelIdResult;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedSourceType: FeedSourceType.YouTubeChannel,
-      userFeedSubscriptionId: parsedFeedSubIdResult.value,
-      channelId: parsedChannelIdResult.value,
-    })
-  );
+  return makeSuccessResult({
+    feedSourceType: FeedSourceType.YouTubeChannel,
+    userFeedSubscriptionId: parsedFeedSubIdResult.value,
+    channelId: parsedChannelIdResult.value,
+  });
 }
 
 export function parseIntervalFeedSource(
@@ -121,10 +116,8 @@ export function parseIntervalFeedSource(
   );
   if (!parsedFeedSubIdResult.success) return parsedFeedSubIdResult;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedSourceType: FeedSourceType.Interval,
-      userFeedSubscriptionId: parsedFeedSubIdResult.value,
-    })
-  );
+  return makeSuccessResult({
+    feedSourceType: FeedSourceType.Interval,
+    userFeedSubscriptionId: parsedFeedSubIdResult.value,
+  });
 }

--- a/packages/shared/src/parsers/userFeedSubscriptions.parser.ts
+++ b/packages/shared/src/parsers/userFeedSubscriptions.parser.ts
@@ -1,7 +1,7 @@
 import {prefixErrorResult} from '@shared/lib/errorUtils.shared';
 import {parseStorageTimestamp, parseZodResult} from '@shared/lib/parser.shared';
 import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
-import {omitUndefined, safeAssertNever} from '@shared/lib/utils.shared';
+import {safeAssertNever} from '@shared/lib/utils.shared';
 
 import {parseAccountId} from '@shared/parsers/accounts.parser';
 import {parseDeliverySchedule} from '@shared/parsers/deliverySchedules.parser';
@@ -86,22 +86,20 @@ function parseRssUserFeedSubscription(
   const parsedDeliveryScheduleResult = parseDeliverySchedule(parsedResult.value.deliverySchedule);
   if (!parsedDeliveryScheduleResult.success) return parsedDeliveryScheduleResult;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedSourceType: FeedSourceType.RSS,
-      url: parsedResult.value.url,
-      title: parsedResult.value.title,
-      userFeedSubscriptionId: parsedUserFeedSubscriptionIdResult.value,
-      accountId: parsedAccountIdResult.value,
-      isActive: parsedResult.value.isActive,
-      deliverySchedule: parsedDeliveryScheduleResult.value,
-      createdTime: parseStorageTimestamp(parsedResult.value.createdTime),
-      lastUpdatedTime: parseStorageTimestamp(parsedResult.value.lastUpdatedTime),
-      unsubscribedTime: parsedResult.value.unsubscribedTime
-        ? parseStorageTimestamp(parsedResult.value.unsubscribedTime)
-        : undefined,
-    })
-  );
+  return makeSuccessResult({
+    feedSourceType: FeedSourceType.RSS,
+    url: parsedResult.value.url,
+    title: parsedResult.value.title,
+    userFeedSubscriptionId: parsedUserFeedSubscriptionIdResult.value,
+    accountId: parsedAccountIdResult.value,
+    isActive: parsedResult.value.isActive,
+    deliverySchedule: parsedDeliveryScheduleResult.value,
+    createdTime: parseStorageTimestamp(parsedResult.value.createdTime),
+    lastUpdatedTime: parseStorageTimestamp(parsedResult.value.lastUpdatedTime),
+    unsubscribedTime: parsedResult.value.unsubscribedTime
+      ? parseStorageTimestamp(parsedResult.value.unsubscribedTime)
+      : undefined,
+  });
 }
 
 function parseYouTubeChannelUserFeedSubscription(
@@ -129,21 +127,19 @@ function parseYouTubeChannelUserFeedSubscription(
   const parsedChannelIdResult = parseYouTubeChannelId(parsedResult.value.channelId);
   if (!parsedChannelIdResult.success) return parsedChannelIdResult;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedSourceType: FeedSourceType.YouTubeChannel,
-      channelId: parsedChannelIdResult.value,
-      userFeedSubscriptionId: parsedUserFeedSubscriptionIdResult.value,
-      accountId: parsedAccountIdResult.value,
-      isActive: parsedResult.value.isActive,
-      deliverySchedule: parsedDeliveryScheduleResult.value,
-      createdTime: parseStorageTimestamp(parsedResult.value.createdTime),
-      lastUpdatedTime: parseStorageTimestamp(parsedResult.value.lastUpdatedTime),
-      unsubscribedTime: parsedResult.value.unsubscribedTime
-        ? parseStorageTimestamp(parsedResult.value.unsubscribedTime)
-        : undefined,
-    })
-  );
+  return makeSuccessResult({
+    feedSourceType: FeedSourceType.YouTubeChannel,
+    channelId: parsedChannelIdResult.value,
+    userFeedSubscriptionId: parsedUserFeedSubscriptionIdResult.value,
+    accountId: parsedAccountIdResult.value,
+    isActive: parsedResult.value.isActive,
+    deliverySchedule: parsedDeliveryScheduleResult.value,
+    createdTime: parseStorageTimestamp(parsedResult.value.createdTime),
+    lastUpdatedTime: parseStorageTimestamp(parsedResult.value.lastUpdatedTime),
+    unsubscribedTime: parsedResult.value.unsubscribedTime
+      ? parseStorageTimestamp(parsedResult.value.unsubscribedTime)
+      : undefined,
+  });
 }
 
 function parseIntervalUserFeedSubscription(
@@ -168,21 +164,19 @@ function parseIntervalUserFeedSubscription(
   const parsedDeliveryScheduleResult = parseDeliverySchedule(parsedResult.value.deliverySchedule);
   if (!parsedDeliveryScheduleResult.success) return parsedDeliveryScheduleResult;
 
-  return makeSuccessResult(
-    omitUndefined({
-      feedSourceType: FeedSourceType.Interval,
-      intervalSeconds: parsedResult.value.intervalSeconds,
-      userFeedSubscriptionId: parsedUserFeedSubscriptionIdResult.value,
-      accountId: parsedAccountIdResult.value,
-      isActive: parsedResult.value.isActive,
-      deliverySchedule: parsedDeliveryScheduleResult.value,
-      createdTime: parseStorageTimestamp(parsedResult.value.createdTime),
-      lastUpdatedTime: parseStorageTimestamp(parsedResult.value.lastUpdatedTime),
-      unsubscribedTime: parsedResult.value.unsubscribedTime
-        ? parseStorageTimestamp(parsedResult.value.unsubscribedTime)
-        : undefined,
-    })
-  );
+  return makeSuccessResult({
+    feedSourceType: FeedSourceType.Interval,
+    intervalSeconds: parsedResult.value.intervalSeconds,
+    userFeedSubscriptionId: parsedUserFeedSubscriptionIdResult.value,
+    accountId: parsedAccountIdResult.value,
+    isActive: parsedResult.value.isActive,
+    deliverySchedule: parsedDeliveryScheduleResult.value,
+    createdTime: parseStorageTimestamp(parsedResult.value.createdTime),
+    lastUpdatedTime: parseStorageTimestamp(parsedResult.value.lastUpdatedTime),
+    unsubscribedTime: parsedResult.value.unsubscribedTime
+      ? parseStorageTimestamp(parsedResult.value.unsubscribedTime)
+      : undefined,
+  });
 }
 
 /**
@@ -209,7 +203,7 @@ export function toStorageUserFeedSubscription(
 function toStorageRssUserFeedSubscription(
   userFeedSubscription: RssUserFeedSubscription
 ): UserFeedSubscriptionFromStorage {
-  return omitUndefined({
+  return {
     feedSourceType: FeedSourceType.RSS,
     userFeedSubscriptionId: userFeedSubscription.userFeedSubscriptionId,
     url: userFeedSubscription.url,
@@ -220,13 +214,13 @@ function toStorageRssUserFeedSubscription(
     createdTime: userFeedSubscription.createdTime,
     lastUpdatedTime: userFeedSubscription.lastUpdatedTime,
     deliverySchedule: toStorageDeliverySchedule(userFeedSubscription.deliverySchedule),
-  });
+  };
 }
 
 function toStorageYouTubeChannelUserFeedSubscription(
   userFeedSubscription: YouTubeChannelUserFeedSubscription
 ): UserFeedSubscriptionFromStorage {
-  return omitUndefined({
+  return {
     feedSourceType: FeedSourceType.YouTubeChannel,
     userFeedSubscriptionId: userFeedSubscription.userFeedSubscriptionId,
     channelId: userFeedSubscription.channelId,
@@ -236,13 +230,13 @@ function toStorageYouTubeChannelUserFeedSubscription(
     createdTime: userFeedSubscription.createdTime,
     lastUpdatedTime: userFeedSubscription.lastUpdatedTime,
     deliverySchedule: toStorageDeliverySchedule(userFeedSubscription.deliverySchedule),
-  });
+  };
 }
 
 function toStorageIntervalUserFeedSubscription(
   userFeedSubscription: IntervalUserFeedSubscription
 ): UserFeedSubscriptionFromStorage {
-  return omitUndefined({
+  return {
     feedSourceType: FeedSourceType.Interval,
     intervalSeconds: userFeedSubscription.intervalSeconds,
     userFeedSubscriptionId: userFeedSubscription.userFeedSubscriptionId,
@@ -252,5 +246,5 @@ function toStorageIntervalUserFeedSubscription(
     createdTime: userFeedSubscription.createdTime,
     lastUpdatedTime: userFeedSubscription.lastUpdatedTime,
     deliverySchedule: toStorageDeliverySchedule(userFeedSubscription.deliverySchedule),
-  });
+  };
 }

--- a/packages/shared/src/schemas/experiments.schema.ts
+++ b/packages/shared/src/schemas/experiments.schema.ts
@@ -13,7 +13,7 @@ export const ExperimentVisibilitySchema = z.nativeEnum(ExperimentVisibility);
 /**
  * Zod schema for an {@link ExperimentDefinition} persisted to Firestore.
  */
-export const BaseExperimentDefinitionSchema = z.object({
+const BaseExperimentDefinitionSchema = z.object({
   experimentId: ExperimentIdSchema,
   experimentType: ExperimentTypeSchema,
   environments: z.array(EnvironmentSchema),
@@ -23,28 +23,27 @@ export const BaseExperimentDefinitionSchema = z.object({
   defaultIsEnabled: z.boolean(),
 });
 
-export type BaseExperimentDefinitionFromStorage = z.infer<typeof BaseExperimentDefinitionSchema>;
-
-export const BooleanExperimentDefinitionSchema = BaseExperimentDefinitionSchema.extend({
+const BooleanExperimentDefinitionSchema = BaseExperimentDefinitionSchema.extend({
   experimentType: z.literal(ExperimentType.Boolean),
 });
 
-export type BooleanExperimentDefinitionFromStorage = z.infer<
-  typeof BooleanExperimentDefinitionSchema
->;
+type BooleanExperimentDefinitionFromStorage = z.infer<typeof BooleanExperimentDefinitionSchema>;
 
-export const StringExperimentDefinitionSchema = BaseExperimentDefinitionSchema.extend({
+const StringExperimentDefinitionSchema = BaseExperimentDefinitionSchema.extend({
   experimentType: z.literal(ExperimentType.String),
   defaultValue: z.string(),
 });
 
-export type StringExperimentDefinitionFromStorage = z.infer<
-  typeof StringExperimentDefinitionSchema
->;
+type StringExperimentDefinitionFromStorage = z.infer<typeof StringExperimentDefinitionSchema>;
 
 export type ExperimentDefinitionFromStorage =
   | BooleanExperimentDefinitionFromStorage
   | StringExperimentDefinitionFromStorage;
+
+export const ExperimentDefinitionSchema = z.union([
+  BooleanExperimentDefinitionSchema,
+  StringExperimentDefinitionSchema,
+]);
 
 /**
  * Zod schema for an {@link ExperimentOverride} persisted to Firestore.

--- a/packages/shared/src/storage/deliverySchedules.storage.ts
+++ b/packages/shared/src/storage/deliverySchedules.storage.ts
@@ -1,5 +1,3 @@
-import {logger} from '@shared/services/logger.shared';
-
 import {
   IMMEDIATE_DELIVERY_SCHEDULE,
   makeDaysAndTimesOfWeekDeliverySchedule,
@@ -7,7 +5,7 @@ import {
   NEVER_DELIVERY_SCHEDULE,
 } from '@shared/lib/deliverySchedules.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
-import {assertNever, safeAssertNever} from '@shared/lib/utils.shared';
+import {assertNever} from '@shared/lib/utils.shared';
 
 import type {DeliverySchedule} from '@shared/types/deliverySchedules.types';
 import {DeliveryScheduleType} from '@shared/types/deliverySchedules.types';
@@ -65,11 +63,6 @@ export function toStorageDeliverySchedule(
         hours: deliverySchedule.hours,
       };
     default:
-      safeAssertNever(deliverySchedule);
-      logger.error(new Error('Unknown delivery schedule type'), {deliverySchedule});
-      // Fallback to an immediate delivery schedule to avoid missing items.
-      return {
-        scheduleType: DeliveryScheduleType.Immediate,
-      };
+      assertNever(deliverySchedule);
   }
 }

--- a/packages/shared/src/storage/experiments.storage.ts
+++ b/packages/shared/src/storage/experiments.storage.ts
@@ -1,0 +1,112 @@
+import {makeSuccessResult} from '@shared/lib/results.shared';
+import {assertNever} from '@shared/lib/utils.shared';
+
+import {parseAccountId} from '@shared/parsers/accounts.parser';
+
+import type {AccountExperimentsState, ExperimentDefinition} from '@shared/types/experiments.types';
+import {ExperimentType} from '@shared/types/experiments.types';
+import type {Result} from '@shared/types/results.types';
+
+import type {
+  AccountExperimentsStateFromStorage,
+  ExperimentDefinitionFromStorage,
+} from '@shared/schemas/experiments.schema';
+
+/**
+ * Converts an {@link ExperimentDefinitionFromStorage} into an {@link ExperimentDefinition}.
+ */
+export function fromStorageExperimentDefinition(
+  experimentDefinitionFromStorage: ExperimentDefinitionFromStorage
+): Result<ExperimentDefinition> {
+  switch (experimentDefinitionFromStorage.experimentType) {
+    case ExperimentType.Boolean:
+      return makeSuccessResult({
+        experimentType: ExperimentType.Boolean,
+        defaultIsEnabled: experimentDefinitionFromStorage.defaultIsEnabled,
+        experimentId: experimentDefinitionFromStorage.experimentId,
+        environments: experimentDefinitionFromStorage.environments,
+        visibility: experimentDefinitionFromStorage.visibility,
+        title: experimentDefinitionFromStorage.title,
+        description: experimentDefinitionFromStorage.description,
+      });
+    case ExperimentType.String:
+      return makeSuccessResult({
+        experimentType: ExperimentType.String,
+        defaultIsEnabled: experimentDefinitionFromStorage.defaultIsEnabled,
+        defaultValue: experimentDefinitionFromStorage.defaultValue,
+        experimentId: experimentDefinitionFromStorage.experimentId,
+        environments: experimentDefinitionFromStorage.environments,
+        visibility: experimentDefinitionFromStorage.visibility,
+        title: experimentDefinitionFromStorage.title,
+        description: experimentDefinitionFromStorage.description,
+      });
+    default:
+      assertNever(experimentDefinitionFromStorage);
+  }
+}
+
+/**
+ * Converts an {@link ExperimentDefinition} into an {@link ExperimentDefinitionFromStorage}.
+ */
+export function toStorageExperimentDefinition(
+  experimentDefinition: ExperimentDefinition
+): ExperimentDefinitionFromStorage {
+  switch (experimentDefinition.experimentType) {
+    case ExperimentType.Boolean:
+      return {
+        experimentId: experimentDefinition.experimentId,
+        experimentType: ExperimentType.Boolean,
+        defaultIsEnabled: experimentDefinition.defaultIsEnabled,
+        environments: [...experimentDefinition.environments],
+        visibility: experimentDefinition.visibility,
+        title: experimentDefinition.title,
+        description: experimentDefinition.description,
+      };
+    case ExperimentType.String:
+      return {
+        experimentId: experimentDefinition.experimentId,
+        experimentType: ExperimentType.String,
+        environments: [...experimentDefinition.environments],
+        visibility: experimentDefinition.visibility,
+        title: experimentDefinition.title,
+        description: experimentDefinition.description,
+        defaultIsEnabled: experimentDefinition.defaultIsEnabled,
+        defaultValue: experimentDefinition.defaultValue,
+      };
+    default:
+      assertNever(experimentDefinition);
+  }
+}
+
+/**
+ * Converts an {@link AccountExperimentsStateFromStorage} into an {@link AccountExperimentsState}.
+ */
+export function fromStorageAccountExperimentsState(
+  accountExperimentsStateFromStorage: AccountExperimentsStateFromStorage
+): Result<AccountExperimentsState> {
+  const parsedAccountId = parseAccountId(accountExperimentsStateFromStorage.accountId);
+  if (!parsedAccountId.success) return parsedAccountId;
+
+  return makeSuccessResult({
+    accountId: parsedAccountId.value,
+    accountVisibility: accountExperimentsStateFromStorage.accountVisibility,
+    experimentOverrides: accountExperimentsStateFromStorage.experimentOverrides,
+    createdTime: accountExperimentsStateFromStorage.createdTime,
+    lastUpdatedTime: accountExperimentsStateFromStorage.lastUpdatedTime,
+  });
+}
+
+/**
+ * Converts an {@link AccountExperimentsState} into an {@link AccountExperimentsStateFromStorage}.
+ */
+export function toStorageAccountExperimentsState(
+  accountExperimentsState: AccountExperimentsState
+): AccountExperimentsStateFromStorage {
+  return {
+    accountId: accountExperimentsState.accountId,
+    accountVisibility: accountExperimentsState.accountVisibility,
+    experimentOverrides: accountExperimentsState.experimentOverrides,
+    createdTime: accountExperimentsState.createdTime,
+    lastUpdatedTime: accountExperimentsState.lastUpdatedTime,
+  };
+}

--- a/packages/sharedClient/src/services/experiments.client.ts
+++ b/packages/sharedClient/src/services/experiments.client.ts
@@ -10,10 +10,7 @@ import {
 } from '@shared/lib/experiments.shared';
 
 import {parseAccountId} from '@shared/parsers/accounts.parser';
-import {
-  parseAccountExperimentsState,
-  toStorageAccountExperimentsState,
-} from '@shared/parsers/experiments.parser';
+import {parseAccountExperimentsState} from '@shared/parsers/experiments.parser';
 
 import type {AccountId} from '@shared/types/accounts.types';
 import type {ClientEnvironment} from '@shared/types/environment.types';
@@ -26,6 +23,7 @@ import type {AsyncResult} from '@shared/types/results.types';
 import type {Consumer, Unsubscribe} from '@shared/types/utils.types';
 
 import type {AccountExperimentsStateFromStorage} from '@shared/schemas/experiments.schema';
+import {toStorageAccountExperimentsState} from '@shared/storage/experiments.storage';
 
 import type {ClientEventLogService} from '@sharedClient/services/eventLog.client';
 import type {ClientFirestoreCollectionService} from '@sharedClient/services/firestore.client';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified and centralized parsing and storage conversion logic for experiments and account experiments state, reducing duplication and improving maintainability.
  - Removed internal utility usage for object serialization, returning plain objects instead.
  - Updated schema exports to use a single unified experiment definition schema.
- **Chores**
  - Reorganized import paths for storage and parsing utilities to better separate concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->