### PR TITLE
Added `error` and `success` props to `Text`

### DIFF
--- a/packages/pwa/src/components/atoms/ButtonIcon.stories.tsx
+++ b/packages/pwa/src/components/atoms/ButtonIcon.stories.tsx
@@ -64,14 +64,14 @@ export const ButtonIconStories: React.FC = () => {
           <ButtonIcon
             name={IconName.Star}
             size={32}
-            className="text-error"
+            className="text-red-2"
             tooltip="Red"
             onClick={handleButtonIconClick}
           />
           <ButtonIcon
             name={IconName.Star}
             size={32}
-            className="text-success"
+            className="text-green-2"
             tooltip="Green"
             onClick={handleButtonIconClick}
           />

--- a/packages/pwa/src/components/atoms/Text.stories.tsx
+++ b/packages/pwa/src/components/atoms/Text.stories.tsx
@@ -38,13 +38,13 @@ export const TextStories: React.FC = () => {
         <FlexColumn gap={2}>
           <P>Default color</P>
           <P light>Light color</P>
-          <P className="text-success">Success color</P>
-          <P className="text-error">Error color</P>
+          <P success>Success color</P>
+          <P error>Error color</P>
           <P>
-            123 <Span className="text-error">THIS SPAN SHOULD BE RED</Span> 789
+            123 <Span error>THIS SPAN SHOULD BE RED</Span> 789
           </P>
           <P className="text-purple-500">
-            123 <Span className="text-error">THIS SPAN SHOULD BE RED</Span> 789
+            123 <Span error>THIS SPAN SHOULD BE RED</Span> 789
           </P>
           <P className="text-purple-500">
             123 <Span>THIS SPAN SHOULD BE GREEN</Span> 789

--- a/packages/pwa/src/components/atoms/Text.tsx
+++ b/packages/pwa/src/components/atoms/Text.tsx
@@ -42,13 +42,20 @@ function getTextAlignClasses(args: {readonly align?: 'left' | 'center' | 'right'
  *
  * TODO: Add back a proper `color` attribute that is semantically cleaner.
  */
-function getColorClasses(args: {readonly light?: boolean}): string {
-  const {light} = args;
+function getColorClasses(args: {
+  readonly light?: boolean;
+  readonly error?: boolean;
+  readonly success?: boolean;
+}): string {
+  const {light, error, success} = args;
+
+  if (error) return 'text-error';
+  if (success) return 'text-success';
+  if (light) return DEFAULT_TEXT_LIGHT_COLOR;
   // TODO: Move this default somewhere else so that every text component doesn't need to set it. It
   // also overrides color of any text component it is inside, which breaks the `span` use case.
-  return light ? DEFAULT_TEXT_LIGHT_COLOR : DEFAULT_TEXT_COLOR;
+  return DEFAULT_TEXT_COLOR;
 }
-
 function getUnderlineClasses(args: {readonly underline?: 'always' | 'hover' | 'never'}): string {
   const {underline} = args;
 
@@ -91,7 +98,7 @@ function getTruncateClasses(args: {readonly truncate?: boolean}): string {
 type TextElement = 'p' | 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 interface TextProps extends HTMLAttributes<HTMLParagraphElement> {
-  readonly as?: TextElement;
+  readonly as: TextElement;
   readonly align?: 'left' | 'center' | 'right';
   readonly bold?: boolean;
   readonly weight?: FontWeight;
@@ -99,18 +106,22 @@ interface TextProps extends HTMLAttributes<HTMLParagraphElement> {
   readonly truncate?: boolean;
   readonly monospace?: boolean;
   readonly light?: boolean;
+  readonly error?: boolean;
+  readonly success?: boolean;
   readonly underline?: 'always' | 'hover' | 'never';
   readonly children: React.ReactNode;
 }
 
 const Text: React.FC<TextProps> = ({
-  as: Component = 'p',
+  as: Component,
   align,
   bold,
   weight,
   flex,
   children,
   light,
+  error,
+  success,
   monospace,
   truncate,
   underline,
@@ -119,7 +130,7 @@ const Text: React.FC<TextProps> = ({
   ...rest
 }) => {
   const classes = cn(
-    getColorClasses({light}),
+    getColorClasses({light, error, success}),
     getUnderlineClasses({underline}),
     getFontWeightClasses({bold, weight}),
     getFontFamilyClasses({monospace}),

--- a/packages/pwa/src/components/atoms/TextIcon.stories.tsx
+++ b/packages/pwa/src/components/atoms/TextIcon.stories.tsx
@@ -25,8 +25,8 @@ export const TextIconStories: React.FC = () => {
 
       <StorySection title="Text icon colors">
         <div className="flex flex-row items-center gap-2">
-          <TextIcon name={IconName.Star} size={32} className="text-error" />
-          <TextIcon name={IconName.Star} size={32} className="text-success" />
+          <TextIcon name={IconName.Star} size={32} className="text-green-2" />
+          <TextIcon name={IconName.Star} size={32} className="text-red-2" />
           <TextIcon name={IconName.Star} size={32} className="text-blue-2" />
         </div>
       </StorySection>

--- a/packages/pwa/src/components/devToolbar/RegisterFeedItemImporterDevTool.tsx
+++ b/packages/pwa/src/components/devToolbar/RegisterFeedItemImporterDevTool.tsx
@@ -20,7 +20,11 @@ const StatusText: React.FC<{
   readonly isError?: boolean;
   readonly children: React.ReactNode;
 }> = ({isError, children}) => {
-  return <P className={isError ? 'text-error' : 'text-success'}>{children}</P>;
+  return (
+    <P error={isError} success={!isError}>
+      {children}
+    </P>
+  );
 };
 
 const FeedItemImporter: React.FC = () => {

--- a/packages/pwa/src/components/feedItems/ImportingFeedItem.tsx
+++ b/packages/pwa/src/components/feedItems/ImportingFeedItem.tsx
@@ -21,7 +21,7 @@ export const ImportingFeedItem: React.FC<{readonly feedItem: FeedItem}> = ({feed
 
   switch (feedItem.importState.status) {
     case FeedItemImportStatus.Failed:
-      return <P className="text-error">Import failed: {feedItem.importState.errorMessage}</P>;
+      return <P error>Import failed: {feedItem.importState.errorMessage}</P>;
 
     case FeedItemImportStatus.Processing: {
       const msSinceImportRequested =

--- a/packages/pwa/src/components/feedSubscriptions/FeedSubscriptionSettings.tsx
+++ b/packages/pwa/src/components/feedSubscriptions/FeedSubscriptionSettings.tsx
@@ -108,7 +108,7 @@ const FeedSubscriptionDeliveryScheduleSetting: React.FC<{
       footer = null;
       break;
     case AsyncStatus.Error:
-      footer = <P className="text-error">{asyncState.error.message}</P>;
+      footer = <P error>{asyncState.error.message}</P>;
       break;
     default:
       assertNever(asyncState);
@@ -203,7 +203,7 @@ const FeedSubscriptionUnsubscribeButton: React.FC<{
       footer = null;
       break;
     case AsyncStatus.Error:
-      footer = <P className="text-error">{asyncState.error.message}</P>;
+      footer = <P error>{asyncState.error.message}</P>;
       break;
     default:
       assertNever(asyncState);

--- a/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
+++ b/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
@@ -127,11 +127,11 @@ const FeedAdder: React.FC = () => {
       </FlexRow>
 
       {asyncState.status === AsyncStatus.Error ? (
-        <P className="text-error">{asyncState.error.message}</P>
+        <P error>{asyncState.error.message}</P>
       ) : asyncState.status === AsyncStatus.Pending ? (
         <P light>Subscribing to feed...</P>
       ) : asyncState.status === AsyncStatus.Success ? (
-        <P className="text-success">Successfully subscribed to feed source</P>
+        <P success>Successfully subscribed to feed source</P>
       ) : null}
 
       <FlexColumn gap={3}>
@@ -198,7 +198,7 @@ const FeedSubscriptionItem: React.FC<{
   return (
     <FlexRow gap={3} padding={3} className="rounded-lg border border-gray-200">
       <FlexColumn flex={1} gap={1}>
-        <P bold className={subscription.isActive ? undefined : 'text-error'}>
+        <P bold error={!subscription.isActive}>
           {primaryRowText}
         </P>
         {secondaryRowText ? <P light>{secondaryRowText}</P> : null}

--- a/packages/pwa/src/screens/ImportScreen.tsx
+++ b/packages/pwa/src/screens/ImportScreen.tsx
@@ -178,7 +178,7 @@ export const ImportScreen: React.FC = () => {
             onChange={handleFileChange}
             className="max-w-sm"
           />
-          {state.fileError ? <P className="text-error">{state.fileError.message}</P> : null}
+          {state.fileError ? <P error>{state.fileError.message}</P> : null}
         </FlexColumn>
 
         {renderParsedItems()}
@@ -217,7 +217,7 @@ const IndividualImportItem: React.FC<WithChildren<IndividualImportItemProps>> = 
           {children}
         </FlexRow>
         <P light>{item.url}</P>
-        {isError ? <P className="text-error">{status.error.message}</P> : null}
+        {isError ? <P error>{status.error.message}</P> : null}
       </FlexColumn>
       <Button onClick={onImport} disabled={isImporting || isImported} size="sm">
         {buttonText}

--- a/packages/pwa/src/screens/SignInScreen.tsx
+++ b/packages/pwa/src/screens/SignInScreen.tsx
@@ -158,7 +158,7 @@ export const SignInScreen: React.FC = () => {
         </P>
       ) : null}
       {state.signInLinkError ? (
-        <P className="text-error" align="center">
+        <P error align="center">
           <Span bold>Error signing in:</Span> {state.signInLinkError.message}
         </P>
       ) : null}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated text color styling throughout the app to use boolean props (e.g., `error`, `success`) instead of explicit CSS class names for error and success states.
  - Enhanced the `Text` component to support `error` and `success` props for more consistent and maintainable styling.

- **Style**
  - Adjusted color variants for icon components to use updated color classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->