### PR TITLE
Moved `Text` component defaults to `globals.css`

### DIFF
--- a/packages/pwa/src/components/atoms/Flex.css.ts
+++ b/packages/pwa/src/components/atoms/Flex.css.ts
@@ -44,10 +44,10 @@ export const flex = recipe({
       false: {flexWrap: 'nowrap'},
     },
     flexValue: {
-      1: {flex: 1},
+      true: {flex: 1},
+      false: {flex: 'none'},
       auto: {flex: 'auto'},
       initial: {flex: 'initial'},
-      none: {flex: 'none'},
     },
     overflow: {
       auto: {overflow: 'auto'},

--- a/packages/pwa/src/components/atoms/Flex.tsx
+++ b/packages/pwa/src/components/atoms/Flex.tsx
@@ -60,7 +60,7 @@ export const FlexColumn: React.FC<WithChildren<Partial<FlexProps>>> = (props) =>
           direction: 'column',
           align: align ?? 'stretch',
           justify: justify ?? 'start',
-          flexValue: getFlexValue(flex),
+          flexValue: flex,
           gap,
           wrap,
           overflow,

--- a/packages/pwa/src/components/atoms/Flex.tsx
+++ b/packages/pwa/src/components/atoms/Flex.tsx
@@ -25,10 +25,6 @@ export interface FlexProps extends HTMLAttributes<HTMLDivElement> {
   readonly padding?: ThemeSpacing;
 }
 
-const getFlexValue = (value: FlexValue | boolean | undefined): FlexValue | undefined => {
-  return value === true ? 1 : value === false ? 'none' : value === undefined ? undefined : value;
-};
-
 export const FlexRow: React.FC<WithChildren<Partial<FlexProps>>> = (props) => {
   const {align, justify, gap, wrap, flex, overflow, padding, children, className, ...rest} = props;
 
@@ -39,7 +35,7 @@ export const FlexRow: React.FC<WithChildren<Partial<FlexProps>>> = (props) => {
           direction: 'row',
           align: align ?? 'center',
           justify: justify ?? 'start',
-          flexValue: getFlexValue(flex),
+          flexValue: flex,
           gap,
           wrap,
           overflow,

--- a/packages/pwa/src/components/atoms/Spacer.stories.tsx
+++ b/packages/pwa/src/components/atoms/Spacer.stories.tsx
@@ -33,7 +33,7 @@ export const SpacerStories: React.FC = () => {
       <StorySection title="Flex spacer">
         <FlexRow className="border-cyan-2 border-3">
           <P>Left</P>
-          <Spacer flex={1} className="bg-orange-2" />
+          <Spacer flex className="bg-orange-2" />
           <P>Right (pushed to end)</P>
         </FlexRow>
       </StorySection>

--- a/packages/pwa/src/components/atoms/Text.stories.tsx
+++ b/packages/pwa/src/components/atoms/Text.stories.tsx
@@ -41,16 +41,16 @@ export const TextStories: React.FC = () => {
           <P success>Success color</P>
           <P error>Error color</P>
           <P>
-            123 <Span error>THIS SPAN SHOULD BE RED</Span> 789
+            DEFAULT <Span error>RED</Span> DEFAULT
           </P>
           <P className="text-purple-2">
-            123 <Span error>THIS SPAN SHOULD BE RED</Span> 789
+            PURPLE <Span error>RED</Span> PURPLE
           </P>
           <P className="text-purple-2">
-            123 <Span success>THIS SPAN SHOULD BE GREEN</Span> 789
+            PURPLE <Span success>GREEN</Span> PURPLE
           </P>
           <P light>
-            123 <Span>THIS SPAN SHOULD BE LIGHT</Span> 789
+            LIGHT <Span>LIGHT</Span> LIGHT
           </P>
         </FlexColumn>
       </StorySection>
@@ -67,14 +67,17 @@ export const TextStories: React.FC = () => {
 
       <StorySection title="Text with flex">
         <FlexRow gap={2}>
-          <P flex={1} className="bg-cyan-1 p-2">
-            flex=1
+          <P flex className="bg-cyan-1 p-2">
+            {`flex={true}`}
+          </P>
+          <P flex={false} className="bg-purple-1 p-2">
+            {`flex={false}`}
           </P>
           <P flex="auto" className="bg-green-1 p-2">
-            flex=auto
+            {`flex="auto"`}
           </P>
           <P flex="initial" className="bg-blue-1 p-2">
-            flex=initial
+            {`flex="initial"`}
           </P>
         </FlexRow>
       </StorySection>

--- a/packages/pwa/src/components/experiments/ExperimentRow.tsx
+++ b/packages/pwa/src/components/experiments/ExperimentRow.tsx
@@ -135,7 +135,7 @@ export const ExperimentRow: React.FC<{
 }> = ({accountExperiment}) => {
   return (
     <FlexRow gap={4} padding={4} className="rounded-lg border border-gray-200">
-      <FlexColumn flex={1} gap={2}>
+      <FlexColumn flex gap={2}>
         <H4 bold>{accountExperiment.definition.title}</H4>
         <P light>{accountExperiment.definition.description}</P>
         <P light>

--- a/packages/pwa/src/components/stories/Typography.stories.tsx
+++ b/packages/pwa/src/components/stories/Typography.stories.tsx
@@ -49,7 +49,7 @@ _Italic paragraph text_
             <H6 light>Normal Typography</H6>
             <P>Regular paragraph text</P>
             <P bold>Bold paragraph text</P>
-            <P className="italic">Italic paragraph text</P>
+            <P italic>Italic paragraph text</P>
           </FlexColumn>
 
           <FlexColumn gap={2}>

--- a/packages/pwa/src/components/views/View.tsx
+++ b/packages/pwa/src/components/views/View.tsx
@@ -468,7 +468,7 @@ export const ViewRenderer: React.FC<{
   });
 
   return (
-    <FlexColumn flex={1} gap={2} padding={4} overflow="auto">
+    <FlexColumn flex gap={2} padding={4} overflow="auto">
       <ViewHeader
         name={defaultViewConfig.name}
         sortBy={viewOptions.sortBy}

--- a/packages/pwa/src/globals.css
+++ b/packages/pwa/src/globals.css
@@ -8,6 +8,12 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
+  * {
+    color: var(--color-text-default);
+    font-family: var(--font-sans);
+    font-weight: normal;
+  }
+
   p {
     @apply text-lg;
   }

--- a/packages/pwa/src/globals.css
+++ b/packages/pwa/src/globals.css
@@ -8,10 +8,10 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
-  * {
+  html,
+  body {
     color: var(--color-text-default);
     font-family: var(--font-sans);
-    font-weight: normal;
   }
 
   p {

--- a/packages/pwa/src/screens/ErrorScreen.tsx
+++ b/packages/pwa/src/screens/ErrorScreen.tsx
@@ -39,8 +39,7 @@ const ErrorScreenAuthFooter: React.FC = () => {
         </H5>
         <Divider y={24} x={1} />
         <Link to={signOutRoute.fullPath} replace>
-          {/* TODO: Add `nowrap` as a prop to `Text`. */}
-          <H5 underline="always" light className="text-nowrap">
+          <H5 underline="always" light nowrap>
             Sign out
           </H5>
         </Link>

--- a/packages/pwa/src/screens/ExperimentsScreen.tsx
+++ b/packages/pwa/src/screens/ExperimentsScreen.tsx
@@ -13,7 +13,7 @@ const ExperimentsScreenMainContent: React.FC = () => {
   const accountExperiments = useExperimentsStore((state) => state.experiments);
 
   return (
-    <FlexColumn flex={1} gap={6} padding={5} overflow="auto">
+    <FlexColumn flex gap={6} padding={5} overflow="auto">
       <H2 bold>Experiments</H2>
 
       <FlexColumn gap={2}>

--- a/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
+++ b/packages/pwa/src/screens/FeedSubscriptionsScreen.tsx
@@ -110,10 +110,10 @@ const FeedAdder: React.FC = () => {
   }, [handleError, setPending, setSuccess, userFeedSubscriptionsService]);
 
   return (
-    <FlexColumn flex={1} gap={3}>
+    <FlexColumn flex gap={3}>
       <H3 bold>Add new feed</H3>
 
-      <FlexRow gap={3} flex={1}>
+      <FlexRow gap={3} flex>
         <Input
           type="text"
           value={urlInputValue}
@@ -197,7 +197,7 @@ const FeedSubscriptionItem: React.FC<{
 
   return (
     <FlexRow gap={3} padding={3} className="border-neutral-2 rounded-lg border">
-      <FlexColumn flex={1} gap={1}>
+      <FlexColumn flex gap={1}>
         <P bold error={!subscription.isActive}>
           {primaryRowText}
         </P>
@@ -217,7 +217,7 @@ const LoadedFeedSubscriptionsListMainContent: React.FC<{
   }
 
   return (
-    <FlexColumn flex={1}>
+    <FlexColumn flex>
       {subscriptions.map((subscription) => (
         <FeedSubscriptionItem
           key={subscription.userFeedSubscriptionId}
@@ -267,7 +267,7 @@ const FeedSubscriptionsList: React.FC = () => {
 export const FeedSubscriptionsScreen: React.FC = () => {
   return (
     <Screen withHeader withLeftSidebar>
-      <FlexRow flex={1} align="start" gap={8} padding={4} overflow="auto">
+      <FlexRow flex align="start" gap={8} padding={4} overflow="auto">
         <FeedAdder />
         <FeedSubscriptionsList />
       </FlexRow>

--- a/packages/pwa/src/screens/ImportScreen.tsx
+++ b/packages/pwa/src/screens/ImportScreen.tsx
@@ -162,7 +162,7 @@ export const ImportScreen: React.FC = () => {
 
   return (
     <Screen withHeader withLeftSidebar>
-      <FlexColumn flex={1} gap={6} padding={5} overflow="auto">
+      <FlexColumn flex gap={6} padding={5} overflow="auto">
         <H2 bold>Import</H2>
 
         <FlexColumn gap={2}>
@@ -211,7 +211,7 @@ const IndividualImportItem: React.FC<WithChildren<IndividualImportItemProps>> = 
 
   return (
     <FlexRow gap={3} padding={3} className="border-neutral-2 rounded-lg border">
-      <FlexColumn flex={1} gap={1}>
+      <FlexColumn flex gap={1}>
         <FlexRow gap={2}>
           <P bold>{item.title}</P>
           {children}

--- a/packages/pwa/src/screens/Screen.tsx
+++ b/packages/pwa/src/screens/Screen.tsx
@@ -29,10 +29,10 @@ export const Screen: React.FC<ScreenProps> = ({
   return (
     <FlexColumn className={styles.screenWrapper}>
       {withHeader ? <AppHeader /> : null}
-      <FlexRow flex={1} align="stretch" overflow="auto">
+      <FlexRow flex align="stretch" overflow="auto">
         {withLeftSidebar ? <LeftSidebar /> : null}
         <FlexColumn
-          flex={1}
+          flex
           overflow="auto"
           gap={gap}
           align={align}

--- a/packages/pwa/src/screens/StoriesScreen.tsx
+++ b/packages/pwa/src/screens/StoriesScreen.tsx
@@ -173,7 +173,7 @@ const StoriesLeftSidebar: React.FC<{
           </P>
         </NavItemLink>
       </div>
-      <FlexColumn flex={1} gap={6} padding={4}>
+      <FlexColumn flex gap={6} padding={4}>
         <SidebarSection
           title="Design system"
           items={getDesignSystemSidebarItems()}
@@ -229,7 +229,7 @@ const StoriesScreenMainContent: React.FC<{
 
   return (
     <FlexColumn
-      flex={1}
+      flex
       gap={8}
       padding={4}
       overflow="auto"

--- a/packages/shared/src/types/flex.types.ts
+++ b/packages/shared/src/types/flex.types.ts
@@ -1,6 +1,6 @@
 import type {ThemeSpacing} from '@shared/types/theme.types';
 
-export type FlexValue = 1 | 'auto' | 'initial' | 'none';
+export type FlexValue = true | false | 'auto' | 'initial';
 
 export type FlexAlign = 'start' | 'end' | 'center' | 'stretch' | 'baseline';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new styling options to text components, including support for `nowrap` and `italic` props.
- **Refactor**
  - Improved how text color, alignment, font weight, underline, and flex options are managed, making component styling more explicit and flexible.
  - Updated text stories and examples to display actual prop values and better reflect current usage.
  - Switched from class-based to prop-based approach for italic and nowrap text styling.
  - Standardized usage of the `flex` prop across multiple components by replacing numeric values with boolean shorthand.
- **Style**
  - Set default text color and font family globally for consistent appearance.
- **Chores**
  - Updated allowed values for flex properties to use booleans (`true`/`false`) instead of previous values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->