### PR TITLE
Add `BaseStoreItemSchema` and clean up experiment schema

### DIFF
--- a/packages/shared/src/lib/utils.shared.ts
+++ b/packages/shared/src/lib/utils.shared.ts
@@ -224,3 +224,32 @@ export function isInteger(value: number): boolean {
 export function isPositiveInteger(value: number): boolean {
   return isInteger(value) && value > 0;
 }
+
+/**
+ * Returns a new typed array with the same length, but each value having been filtered by `filter`.
+ */
+export function filterArray<T>(arr: T[], filter: Func<T, boolean>): T[] {
+  return arr.filter(filter);
+}
+
+/**
+ * Returns a new typed array with the same length, but each value having been transformed by
+ * `mapper`.
+ */
+export function mapArray<Start, End>(arr: Start[], mapper: Func<Start, End>): End[] {
+  return arr.map(mapper);
+}
+
+/**
+ * Returns a new typed object with the same keys, but each value having been transformed by
+ * `mapper`.
+ */
+export function mapObjectValues<Key extends string, Start, End>(
+  obj: Partial<Record<Key, Start>>,
+  mapper: Func<Start, End>,
+  filter?: Func<Key, boolean>
+): Record<Key, End> {
+  const entries = Object.entries(obj).map(([key, value]) => [key as Key, mapper(value as Start)]);
+  const filteredEntries = filter ? filterArray(entries, ([key]) => filter(key as Key)) : entries;
+  return Object.fromEntries(filteredEntries);
+}

--- a/packages/shared/src/schemas/accountSettings.schema.ts
+++ b/packages/shared/src/schemas/accountSettings.schema.ts
@@ -1,14 +1,10 @@
-import {z} from 'zod';
-
 import {AccountIdSchema} from '@shared/schemas/accounts.schema';
-import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
 import {ThemePreferenceSchema} from '@shared/schemas/theme.schema';
+import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
 
-export const AccountSettingsSchema = z.object({
+export const AccountSettingsSchema = BaseStoreItemSchema.extend({
   accountId: AccountIdSchema,
   themePreference: ThemePreferenceSchema,
-  createdTime: FirestoreTimestampSchema.or(z.date()),
-  lastUpdatedTime: FirestoreTimestampSchema.or(z.date()),
 });
 
 /** Type for an {@link AccountSettings} persisted to Firestore. */

--- a/packages/shared/src/schemas/accountSettings.schema.ts
+++ b/packages/shared/src/schemas/accountSettings.schema.ts
@@ -1,3 +1,5 @@
+import type {z} from 'zod';
+
 import {AccountIdSchema} from '@shared/schemas/accounts.schema';
 import {ThemePreferenceSchema} from '@shared/schemas/theme.schema';
 import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';

--- a/packages/shared/src/schemas/eventLog.schema.ts
+++ b/packages/shared/src/schemas/eventLog.schema.ts
@@ -9,9 +9,9 @@ import {AccountIdSchema} from '@shared/schemas/accounts.schema';
 import {ActorSchema} from '@shared/schemas/actors.schema';
 import {ExperimentIdSchema, ExperimentTypeSchema} from '@shared/schemas/experiments.schema';
 import {FeedItemIdSchema} from '@shared/schemas/feedItems.schema';
-import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
 import {ThemePreferenceSchema} from '@shared/schemas/theme.schema';
 import {UserFeedSubscriptionIdSchema} from '@shared/schemas/userFeedSubscriptions.schema';
+import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
 
 // TODO: Consider adding `brand()` and defining `EventId` based on this schema.
 export const EventIdSchema = z.string().uuid();
@@ -99,14 +99,12 @@ const EventLogItemDataSchema = z.discriminatedUnion('eventType', [
 /** Type for an {@link EventLogItemData} persisted to Firestore. */
 export type EventLogItemDataFromStorage = z.infer<typeof EventLogItemDataSchema>;
 
-export const EventLogItemSchema = z.object({
+export const EventLogItemSchema = BaseStoreItemSchema.extend({
   eventId: EventIdSchema,
   accountId: AccountIdSchema,
   actor: ActorSchema,
   environment: z.nativeEnum(Environment),
   data: EventLogItemDataSchema,
-  createdTime: FirestoreTimestampSchema.or(z.date()),
-  lastUpdatedTime: FirestoreTimestampSchema.or(z.date()),
 });
 
 /** Type for an {@link EventLogItem} persisted to Firestore. */

--- a/packages/shared/src/schemas/experiments.schema.ts
+++ b/packages/shared/src/schemas/experiments.schema.ts
@@ -10,6 +10,9 @@ export const ExperimentIdSchema = z.nativeEnum(ExperimentId);
 export const ExperimentTypeSchema = z.nativeEnum(ExperimentType);
 export const ExperimentVisibilitySchema = z.nativeEnum(ExperimentVisibility);
 
+/////////////////////////////
+//  EXPERIMENT DEFINITION  //
+/////////////////////////////
 const BaseExperimentDefinitionSchema = z.object({
   experimentId: ExperimentIdSchema,
   experimentType: ExperimentTypeSchema,
@@ -24,15 +27,13 @@ const BooleanExperimentDefinitionSchema = BaseExperimentDefinitionSchema.extend(
   experimentType: z.literal(ExperimentType.Boolean),
 });
 
-type BooleanExperimentDefinitionFromStorage = z.infer<typeof BooleanExperimentDefinitionSchema>;
-
 const StringExperimentDefinitionSchema = BaseExperimentDefinitionSchema.extend({
   experimentType: z.literal(ExperimentType.String),
   defaultValue: z.string(),
 });
 
+type BooleanExperimentDefinitionFromStorage = z.infer<typeof BooleanExperimentDefinitionSchema>;
 type StringExperimentDefinitionFromStorage = z.infer<typeof StringExperimentDefinitionSchema>;
-
 export type ExperimentDefinitionFromStorage =
   | BooleanExperimentDefinitionFromStorage
   | StringExperimentDefinitionFromStorage;
@@ -43,6 +44,9 @@ export const ExperimentDefinitionSchema = z.union([
   StringExperimentDefinitionSchema,
 ]);
 
+///////////////////////////
+//  EXPERIMENT OVERRIDE  //
+///////////////////////////
 const BaseExperimentOverrideSchema = z.object({
   experimentId: ExperimentIdSchema,
   experimentType: ExperimentTypeSchema,
@@ -63,10 +67,19 @@ const ExperimentOverrideSchema = z.union([
   StringExperimentOverrideSchema,
 ]);
 
+export type BooleanExperimentOverrideFromStorage = z.infer<typeof BooleanExperimentOverrideSchema>;
+export type StringExperimentOverrideFromStorage = z.infer<typeof StringExperimentOverrideSchema>;
+export type ExperimentOverrideFromStorage = z.infer<typeof ExperimentOverrideSchema>;
+
+///////////////////////////
+//  ACCOUNT EXPERIMENTS  //
+///////////////////////////
 export const AccountExperimentsStateSchema = z.object({
   accountId: AccountIdSchema,
   accountVisibility: ExperimentVisibilitySchema,
-  experimentOverrides: z.record(ExperimentIdSchema, ExperimentOverrideSchema),
+  // Intentionall do not use `ExperimentId` as the key type because this may include historical
+  // experiments which are no longer defined in `ExperimentId`. These get filtered out when parsing.
+  experimentOverrides: z.record(z.string(), ExperimentOverrideSchema),
   createdTime: FirestoreTimestampSchema,
   lastUpdatedTime: FirestoreTimestampSchema,
 });

--- a/packages/shared/src/schemas/feedItems.schema.ts
+++ b/packages/shared/src/schemas/feedItems.schema.ts
@@ -9,6 +9,7 @@ import {
 import {AccountIdSchema} from '@shared/schemas/accounts.schema';
 import {FeedSourceSchema} from '@shared/schemas/feedSources.schema';
 import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
+import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
 
 export const FeedItemIdSchema = z.string().uuid();
 
@@ -128,7 +129,7 @@ export type IntervalFeedItemContentFromStorage = z.infer<typeof IntervalFeedItem
 /////////////////
 //  FEED ITEM  //
 /////////////////
-const BaseFeedItemSchema = z.object({
+const BaseFeedItemSchema = BaseStoreItemSchema.extend({
   feedSource: FeedSourceSchema,
   feedItemId: FeedItemIdSchema,
   feedItemContentType: z.nativeEnum(FeedItemContentType),
@@ -137,8 +138,6 @@ const BaseFeedItemSchema = z.object({
   triageStatus: z.nativeEnum(TriageStatus),
   content: BaseFeedItemContentSchema,
   tagIds: z.record(z.string(), z.literal(true).optional()),
-  createdTime: FirestoreTimestampSchema.or(z.date()),
-  lastUpdatedTime: FirestoreTimestampSchema.or(z.date()),
 });
 
 const ArticleFeedItemSchema = BaseFeedItemSchema.extend({

--- a/packages/shared/src/schemas/tags.schema.ts
+++ b/packages/shared/src/schemas/tags.schema.ts
@@ -2,17 +2,15 @@ import {z} from 'zod';
 
 import {SystemTagId} from '@shared/types/tags.types';
 
-import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
+import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
 
 export const UserTagIdSchema = z.string().uuid();
 
 export const SystemTagIdSchema = z.nativeEnum(SystemTagId);
 
-export const UserTagSchema = z.object({
+export const UserTagSchema = BaseStoreItemSchema.extend({
   tagId: UserTagIdSchema,
   name: z.string().min(1).max(255),
-  createdTime: FirestoreTimestampSchema.or(z.date()),
-  lastUpdatedTime: FirestoreTimestampSchema.or(z.date()),
 });
 
 export const SystemTagSchema = z.object({

--- a/packages/shared/src/schemas/utils.schema.ts
+++ b/packages/shared/src/schemas/utils.schema.ts
@@ -1,0 +1,8 @@
+import {z} from 'zod';
+
+import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
+
+export const BaseStoreItemSchema = z.object({
+  createdTime: FirestoreTimestampSchema.or(z.date()),
+  lastUpdatedTime: FirestoreTimestampSchema.or(z.date()),
+});

--- a/packages/shared/src/storage/experiments.storage.ts
+++ b/packages/shared/src/storage/experiments.storage.ts
@@ -168,7 +168,7 @@ export function fromStorageAccountExperimentsState(
 
 function fromStorageExperimentOverride(
   experimentOverrideFromStorage: ExperimentOverrideFromStorage
-): Result<ExperimentOverride> {
+): ExperimentOverride {
   switch (experimentOverrideFromStorage.experimentType) {
     case ExperimentType.Boolean:
       return fromStorageBooleanExperimentOverride(experimentOverrideFromStorage);
@@ -181,21 +181,21 @@ function fromStorageExperimentOverride(
 
 function fromStorageBooleanExperimentOverride(
   experimentOverrideFromStorage: BooleanExperimentOverrideFromStorage
-): Result<BooleanExperimentOverride> {
-  return makeSuccessResult({
+): BooleanExperimentOverride {
+  return {
     experimentType: ExperimentType.Boolean,
     experimentId: experimentOverrideFromStorage.experimentId,
     isEnabled: experimentOverrideFromStorage.isEnabled,
-  });
+  };
 }
 
 function fromStorageStringExperimentOverride(
   experimentOverrideFromStorage: StringExperimentOverrideFromStorage
-): Result<StringExperimentOverride> {
-  return makeSuccessResult({
+): StringExperimentOverride {
+  return {
     experimentType: ExperimentType.String,
     experimentId: experimentOverrideFromStorage.experimentId,
     value: experimentOverrideFromStorage.value,
     isEnabled: experimentOverrideFromStorage.isEnabled,
-  });
+  };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a unified schema for items with creation and update timestamps, improving consistency across account settings, event logs, feed items, and user tags.
  - Added utility functions for filtering and mapping arrays and objects.

- **Improvements**
  - Enhanced experiment override handling with structured serialization and deserialization, ensuring more robust and type-safe data management.
  - Updated experiment override keys to support historical experiments, improving compatibility with legacy data.

- **Documentation**
  - Added section headers and clearer type aliases for experiment schemas to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->