### PR TITLE
Refactored how Firebase initialized on server to match client

### DIFF
--- a/packages/functions/src/lib/firebase.func.ts
+++ b/packages/functions/src/lib/firebase.func.ts
@@ -1,0 +1,3 @@
+import {ServerFirebaseService} from '@sharedServer/services/firebase.server';
+
+export const firebaseService = new ServerFirebaseService();

--- a/packages/functions/src/lib/initServices.func.ts
+++ b/packages/functions/src/lib/initServices.func.ts
@@ -1,38 +1,13 @@
 import FirecrawlApp from '@mendable/firecrawl-js';
 import {defineString} from 'firebase-functions/params';
 
-import {
-  ACCOUNT_EXPERIMENTS_DB_COLLECTION,
-  ACCOUNT_SETTINGS_DB_COLLECTION,
-  ACCOUNTS_DB_COLLECTION,
-  EVENT_LOG_DB_COLLECTION,
-  FEED_ITEMS_DB_COLLECTION,
-  FEED_ITEMS_STORAGE_COLLECTION,
-  USER_FEED_SUBSCRIPTIONS_DB_COLLECTION,
-} from '@shared/lib/constants.shared';
+import {FEED_ITEMS_STORAGE_COLLECTION} from '@shared/lib/constants.shared';
 import {prefixErrorResult} from '@shared/lib/errorUtils.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
-
-import {parseAccount, parseAccountId} from '@shared/parsers/accounts.parser';
-import {parseAccountSettings} from '@shared/parsers/accountSettings.parser';
-import {parseEventId, parseEventLogItem} from '@shared/parsers/eventLog.parser';
-import {parseAccountExperimentsState} from '@shared/parsers/experiments.parser';
-import {parseFeedItem, parseFeedItemId} from '@shared/parsers/feedItems.parser';
-import {
-  parseUserFeedSubscription,
-  parseUserFeedSubscriptionId,
-} from '@shared/parsers/userFeedSubscriptions.parser';
 
 import {Environment} from '@shared/types/environment.types';
 import type {Result} from '@shared/types/results.types';
 import type {RssFeedProvider} from '@shared/types/rss.types';
-
-import {toStorageAccount} from '@shared/storage/accounts.storage';
-import {toStorageAccountSettings} from '@shared/storage/accountSettings.storage';
-import {toStorageEventLogItem} from '@shared/storage/eventLog.storage';
-import {toStorageAccountExperimentsState} from '@shared/storage/experiments.storage';
-import {toStorageFeedItem} from '@shared/storage/feedItems.storage';
-import {toStorageUserFeedSubscription} from '@shared/storage/userFeedSubscriptions.storage';
 
 import {ServerAccountsService} from '@sharedServer/services/accounts.server';
 import {ServerAccountSettingsService} from '@sharedServer/services/accountSettings.server';
@@ -40,11 +15,11 @@ import {ServerEventLogService} from '@sharedServer/services/eventLog.server';
 import {ServerExperimentsService} from '@sharedServer/services/experiments.server';
 import {ServerFeedItemsService} from '@sharedServer/services/feedItems.server';
 import {ServerFirecrawlService} from '@sharedServer/services/firecrawl.server';
-import {makeServerFirestoreCollectionService} from '@sharedServer/services/firestore.server';
 import {ServerRssFeedService} from '@sharedServer/services/rssFeed.server';
 import {ServerUserFeedSubscriptionsService} from '@sharedServer/services/userFeedSubscriptions.server';
 import {WipeoutService} from '@sharedServer/services/wipeout.server';
 
+import {firebaseService} from '@src/lib/firebase.func';
 import {getRssFeedProvider} from '@src/lib/rssFeedProvider.func';
 
 const FIRECRAWL_API_KEY = defineString('FIRECRAWL_API_KEY');
@@ -61,83 +36,41 @@ interface InitializedServices {
 
 export function initServices(): Result<InitializedServices, Error> {
   // User feed subscriptions.
-  const userFeedSubscriptionsCollectionService = makeServerFirestoreCollectionService({
-    collectionPath: USER_FEED_SUBSCRIPTIONS_DB_COLLECTION,
-    parseId: parseUserFeedSubscriptionId,
-    toStorage: toStorageUserFeedSubscription,
-    fromStorage: parseUserFeedSubscription,
-  });
-
   const userFeedSubscriptionsService = new ServerUserFeedSubscriptionsService({
-    collectionService: userFeedSubscriptionsCollectionService,
+    firebaseService,
   });
 
   // Event log service.
-  const eventLogCollectionService = makeServerFirestoreCollectionService({
-    collectionPath: EVENT_LOG_DB_COLLECTION,
-    toStorage: toStorageEventLogItem,
-    fromStorage: parseEventLogItem,
-    parseId: parseEventId,
-  });
-
   const eventLogService = new ServerEventLogService({
+    firebaseService,
     environment: ENVIRONMENT,
-    collectionService: eventLogCollectionService,
   });
 
   // Firecrawl service.
   const firecrawlApp = new FirecrawlApp({apiKey: FIRECRAWL_API_KEY.value()});
-  const firecrawlService = new ServerFirecrawlService(firecrawlApp);
+  const firecrawlService = new ServerFirecrawlService({firecrawlApp});
 
   // Feed items service.
-  const feedItemsCollectionService = makeServerFirestoreCollectionService({
-    collectionPath: FEED_ITEMS_DB_COLLECTION,
-    toStorage: toStorageFeedItem,
-    fromStorage: parseFeedItem,
-    parseId: parseFeedItemId,
-  });
-
   const feedItemsService = new ServerFeedItemsService({
-    collectionService: feedItemsCollectionService,
+    firebaseService,
     storageCollectionPath: FEED_ITEMS_STORAGE_COLLECTION,
     eventLogService,
     firecrawlService,
   });
 
   // Account experiments service.
-  const accountExperimentsCollectionService = makeServerFirestoreCollectionService({
-    collectionPath: ACCOUNT_EXPERIMENTS_DB_COLLECTION,
-    parseId: parseAccountId,
-    toStorage: toStorageAccountExperimentsState,
-    fromStorage: parseAccountExperimentsState,
-  });
-
   const experimentsService = new ServerExperimentsService({
-    collectionService: accountExperimentsCollectionService,
+    firebaseService,
   });
 
   // Account settings service.
-  const accountSettingsCollectionService = makeServerFirestoreCollectionService({
-    collectionPath: ACCOUNT_SETTINGS_DB_COLLECTION,
-    parseId: parseAccountId,
-    toStorage: toStorageAccountSettings,
-    fromStorage: parseAccountSettings,
-  });
-
   const accountSettingsService = new ServerAccountSettingsService({
-    collectionService: accountSettingsCollectionService,
+    firebaseService,
   });
 
   // Accounts service.
-  const accountsCollectionService = makeServerFirestoreCollectionService({
-    collectionPath: ACCOUNTS_DB_COLLECTION,
-    toStorage: toStorageAccount,
-    fromStorage: parseAccount,
-    parseId: parseAccountId,
-  });
-
   const accountsService = new ServerAccountsService({
-    collectionService: accountsCollectionService,
+    firebaseService,
     accountSettingsService,
     experimentsService,
   });
@@ -156,10 +89,7 @@ export function initServices(): Result<InitializedServices, Error> {
   }
   const rssFeedProvider = rssFeedProviderResult.value;
 
-  const rssFeedService = new ServerRssFeedService({
-    rssFeedProvider,
-    userFeedSubscriptionsService,
-  });
+  const rssFeedService = new ServerRssFeedService({rssFeedProvider, userFeedSubscriptionsService});
 
   return makeSuccessResult({
     userFeedSubscriptionsService,

--- a/packages/scripts/src/lib/firebase.scripts.ts
+++ b/packages/scripts/src/lib/firebase.scripts.ts
@@ -1,0 +1,3 @@
+import {ServerFirebaseService} from '@sharedServer/services/firebase.server';
+
+export const firebaseService = new ServerFirebaseService();

--- a/packages/sharedClient/src/services/accountSettings.client.ts
+++ b/packages/sharedClient/src/services/accountSettings.client.ts
@@ -29,7 +29,7 @@ type ClientAccountSettingsCollectionService = ClientFirestoreCollectionService<
 export class ClientAccountSettingsService {
   private readonly accountId: AccountId;
   private readonly eventLogService: ClientEventLogService;
-  private readonly accountSettingsCollectionService: ClientAccountSettingsCollectionService;
+  private readonly collectionService: ClientAccountSettingsCollectionService;
 
   constructor(args: {
     readonly accountId: AccountId;
@@ -39,7 +39,7 @@ export class ClientAccountSettingsService {
     this.accountId = args.accountId;
     this.eventLogService = args.eventLogService;
 
-    this.accountSettingsCollectionService = makeClientFirestoreCollectionService({
+    this.collectionService = makeClientFirestoreCollectionService({
       firebaseService: args.firebaseService,
       collectionPath: ACCOUNT_SETTINGS_DB_COLLECTION,
       toStorage: toStorageAccountSettings,
@@ -66,15 +66,11 @@ export class ClientAccountSettingsService {
       onError(betterError);
     };
 
-    return this.accountSettingsCollectionService.watchDoc(
-      this.accountId,
-      handleOnData,
-      handleOnError
-    );
+    return this.collectionService.watchDoc(this.accountId, handleOnData, handleOnError);
   }
 
   public async updateThemePreference(themePreference: ThemePreference): AsyncResult<void, Error> {
-    const result = await this.accountSettingsCollectionService.updateDoc(this.accountId, {
+    const result = await this.collectionService.updateDoc(this.accountId, {
       themePreference,
     });
     if (result.success) {

--- a/packages/sharedClient/src/services/experiments.client.ts
+++ b/packages/sharedClient/src/services/experiments.client.ts
@@ -43,7 +43,7 @@ export class ClientExperimentsService {
   private readonly isInternalAccount: boolean;
   private readonly eventLogService: ClientEventLogService;
   private accountExperimentsState: AccountExperimentsState | null = null;
-  private readonly accountExperimentsCollectionService: ClientAccountExperimentsCollectionService;
+  private readonly collectionService: ClientAccountExperimentsCollectionService;
 
   constructor(args: {
     readonly accountId: AccountId;
@@ -57,7 +57,7 @@ export class ClientExperimentsService {
     this.environment = args.environment;
     this.eventLogService = args.eventLogService;
 
-    this.accountExperimentsCollectionService = makeClientFirestoreCollectionService({
+    this.collectionService = makeClientFirestoreCollectionService({
       firebaseService: args.firebaseService,
       collectionPath: ACCOUNT_EXPERIMENTS_DB_COLLECTION,
       toStorage: toStorageAccountExperimentsState,
@@ -80,7 +80,7 @@ export class ClientExperimentsService {
       callback(this.accountExperimentsState);
     }
 
-    return this.accountExperimentsCollectionService.watchDoc(
+    return this.collectionService.watchDoc(
       this.accountId,
       (accountExperimentsState) => {
         if (!accountExperimentsState) {
@@ -138,7 +138,7 @@ export class ClientExperimentsService {
     const pathToUpdate = `experimentOverrides.${experimentId}`;
     const experimentOverride = makeBooleanExperimentOverride({experimentId, isEnabled});
 
-    const updateResult = await this.accountExperimentsCollectionService.updateDoc(this.accountId, {
+    const updateResult = await this.collectionService.updateDoc(this.accountId, {
       [pathToUpdate]: experimentOverride,
     });
 
@@ -173,7 +173,7 @@ export class ClientExperimentsService {
       value,
     });
 
-    const updateResult = await this.accountExperimentsCollectionService.updateDoc(this.accountId, {
+    const updateResult = await this.collectionService.updateDoc(this.accountId, {
       [pathToUpdate]: experimentOverride,
     });
 

--- a/packages/sharedServer/src/services/accountSettings.server.ts
+++ b/packages/sharedServer/src/services/accountSettings.server.ts
@@ -1,4 +1,8 @@
 import {makeDefaultAccountSettings} from '@shared/lib/accountSettings.shared';
+import {ACCOUNT_SETTINGS_DB_COLLECTION} from '@shared/lib/constants.shared';
+
+import {parseAccountId} from '@shared/parsers/accounts.parser';
+import {parseAccountSettings} from '@shared/parsers/accountSettings.parser';
 
 import type {AccountId} from '@shared/types/accounts.types';
 import type {AccountSettings} from '@shared/types/accountSettings.types';
@@ -6,8 +10,11 @@ import type {AsyncResult} from '@shared/types/results.types';
 import type {ThemePreference} from '@shared/types/theme.types';
 
 import type {AccountSettingsFromStorage} from '@shared/schemas/accountSettings.schema';
+import {toStorageAccountSettings} from '@shared/storage/accountSettings.storage';
 
+import type {ServerFirebaseService} from '@sharedServer/services/firebase.server';
 import type {ServerFirestoreCollectionService} from '@sharedServer/services/firestore.server';
+import {makeServerFirestoreCollectionService} from '@sharedServer/services/firestore.server';
 
 type ServerAccountSettingsCollectionService = ServerFirestoreCollectionService<
   AccountId,
@@ -18,8 +25,14 @@ type ServerAccountSettingsCollectionService = ServerFirestoreCollectionService<
 export class ServerAccountSettingsService {
   private readonly collectionService: ServerAccountSettingsCollectionService;
 
-  constructor(args: {readonly collectionService: ServerAccountSettingsCollectionService}) {
-    this.collectionService = args.collectionService;
+  constructor(args: {readonly firebaseService: ServerFirebaseService}) {
+    this.collectionService = makeServerFirestoreCollectionService({
+      firebaseService: args.firebaseService,
+      collectionPath: ACCOUNT_SETTINGS_DB_COLLECTION,
+      parseId: parseAccountId,
+      toStorage: toStorageAccountSettings,
+      fromStorage: parseAccountSettings,
+    });
   }
 
   public async initializeForAccount(args: {

--- a/packages/sharedServer/src/services/experiments.server.ts
+++ b/packages/sharedServer/src/services/experiments.server.ts
@@ -1,5 +1,9 @@
 import {isInternalAccount} from '@shared/lib/accounts.shared';
+import {ACCOUNT_EXPERIMENTS_DB_COLLECTION} from '@shared/lib/constants.shared';
 import {makeDefaultAccountExperimentsState} from '@shared/lib/experiments.shared';
+
+import {parseAccountId} from '@shared/parsers/accounts.parser';
+import {parseAccountExperimentsState} from '@shared/parsers/experiments.parser';
 
 import type {AccountId} from '@shared/types/accounts.types';
 import type {EmailAddress} from '@shared/types/emails.types';
@@ -7,7 +11,10 @@ import type {AccountExperimentsState} from '@shared/types/experiments.types';
 import type {AsyncResult} from '@shared/types/results.types';
 
 import type {AccountExperimentsStateFromStorage} from '@shared/schemas/experiments.schema';
+import {toStorageAccountExperimentsState} from '@shared/storage/experiments.storage';
 
+import type {ServerFirebaseService} from '@sharedServer/services/firebase.server';
+import {makeServerFirestoreCollectionService} from '@sharedServer/services/firestore.server';
 import type {ServerFirestoreCollectionService} from '@sharedServer/services/firestore.server';
 
 type ServerAccountExperimentsCollectionService = ServerFirestoreCollectionService<
@@ -19,8 +26,14 @@ type ServerAccountExperimentsCollectionService = ServerFirestoreCollectionServic
 export class ServerExperimentsService {
   private readonly collectionService: ServerAccountExperimentsCollectionService;
 
-  constructor(args: {readonly collectionService: ServerAccountExperimentsCollectionService}) {
-    this.collectionService = args.collectionService;
+  constructor(args: {readonly firebaseService: ServerFirebaseService}) {
+    this.collectionService = makeServerFirestoreCollectionService({
+      firebaseService: args.firebaseService,
+      collectionPath: ACCOUNT_EXPERIMENTS_DB_COLLECTION,
+      parseId: parseAccountId,
+      toStorage: toStorageAccountExperimentsState,
+      fromStorage: parseAccountExperimentsState,
+    });
   }
 
   public async initializeForAccount(args: {

--- a/packages/sharedServer/src/services/firebase.server.ts
+++ b/packages/sharedServer/src/services/firebase.server.ts
@@ -6,21 +6,33 @@ import type {Storage} from 'firebase-admin/storage';
 
 import {logger} from '@shared/services/logger.shared';
 
-import {prefixError} from '@shared/lib/errorUtils.shared';
+import {asyncTry} from '@shared/lib/errorUtils.shared';
 
 export const serverTimestampSupplier = (): FieldValue => FieldValue.serverTimestamp();
 
-enableFirebaseTelemetry({
-  forceDevExport: false,
-}).catch((error) => {
-  logger.error(prefixError(error, 'Failed to enable Firebase telemetry'));
-});
+const enableTelemetryResult = await asyncTry(async () =>
+  enableFirebaseTelemetry({forceDevExport: false})
+);
+
+if (!enableTelemetryResult.success) {
+  const message = 'Failed to enable Firebase telemetry. Continuing without telemetry.';
+  logger.warn(message, {error: enableTelemetryResult.error});
+}
 
 export class ServerFirebaseService {
   private storageInstance: Storage;
   private firestoreInstance: Firestore;
 
   constructor() {
+    if (admin.apps.length !== 0) {
+      const message = 'Only a single `ServerFirebaseService` should be initialized on the server.';
+      const error = new Error(message);
+      logger.error(error);
+      // Consider it a fatal error if multiple `ServerFirebaseService`s are initialized.
+      // eslint-disable-next-line no-restricted-syntax
+      throw error;
+    }
+
     admin.initializeApp();
 
     this.storageInstance = admin.storage();

--- a/packages/sharedServer/src/services/firebase.server.ts
+++ b/packages/sharedServer/src/services/firebase.server.ts
@@ -20,6 +20,7 @@ async function enableTelemetry(): AsyncResult<void, Error> {
     const message = 'Failed to enable Firebase telemetry. Continuing without telemetry.';
     logger.warn(message, {error: enableTelemetryResult.error});
   }
+  return enableTelemetryResult;
 }
 
 export class ServerFirebaseService {

--- a/packages/sharedServer/src/services/firebase.server.ts
+++ b/packages/sharedServer/src/services/firebase.server.ts
@@ -8,15 +8,18 @@ import {logger} from '@shared/services/logger.shared';
 
 import {asyncTry} from '@shared/lib/errorUtils.shared';
 
+import type {AsyncResult} from '@shared/types/results.types';
+
 export const serverTimestampSupplier = (): FieldValue => FieldValue.serverTimestamp();
 
-const enableTelemetryResult = await asyncTry(async () =>
-  enableFirebaseTelemetry({forceDevExport: false})
-);
-
-if (!enableTelemetryResult.success) {
-  const message = 'Failed to enable Firebase telemetry. Continuing without telemetry.';
-  logger.warn(message, {error: enableTelemetryResult.error});
+async function enableTelemetry(): AsyncResult<void, Error> {
+  const enableTelemetryResult = await asyncTry(async () =>
+    enableFirebaseTelemetry({forceDevExport: false})
+  );
+  if (!enableTelemetryResult.success) {
+    const message = 'Failed to enable Firebase telemetry. Continuing without telemetry.';
+    logger.warn(message, {error: enableTelemetryResult.error});
+  }
 }
 
 export class ServerFirebaseService {
@@ -34,6 +37,9 @@ export class ServerFirebaseService {
     }
 
     admin.initializeApp();
+
+    // Enable telemetry, ignoring errors.
+    void enableTelemetry();
 
     this.storageInstance = admin.storage();
 

--- a/packages/sharedServer/src/services/firebase.server.ts
+++ b/packages/sharedServer/src/services/firebase.server.ts
@@ -1,19 +1,12 @@
 import {enableFirebaseTelemetry} from '@genkit-ai/firebase';
 import admin from 'firebase-admin';
 import {FieldValue} from 'firebase-admin/firestore';
+import type {Firestore} from 'firebase-admin/firestore';
+import type {Storage} from 'firebase-admin/storage';
 
 import {logger} from '@shared/services/logger.shared';
 
 import {prefixError} from '@shared/lib/errorUtils.shared';
-
-admin.initializeApp();
-
-export const firestore = admin.firestore();
-firestore.settings({
-  ignoreUndefinedProperties: true,
-});
-
-export const storage = admin.storage();
 
 export const serverTimestampSupplier = (): FieldValue => FieldValue.serverTimestamp();
 
@@ -22,3 +15,25 @@ enableFirebaseTelemetry({
 }).catch((error) => {
   logger.error(prefixError(error, 'Failed to enable Firebase telemetry'));
 });
+
+export class ServerFirebaseService {
+  private storageInstance: Storage;
+  private firestoreInstance: Firestore;
+
+  constructor() {
+    admin.initializeApp();
+
+    this.storageInstance = admin.storage();
+
+    this.firestoreInstance = admin.firestore();
+    this.firestoreInstance.settings({ignoreUndefinedProperties: true});
+  }
+
+  public get storage(): Storage {
+    return this.storageInstance;
+  }
+
+  public get firestore(): Firestore {
+    return this.firestoreInstance;
+  }
+}

--- a/packages/sharedServer/src/services/firecrawl.server.ts
+++ b/packages/sharedServer/src/services/firecrawl.server.ts
@@ -7,7 +7,11 @@ import type {ParsedFirecrawlData, RawFirecrawlResponse} from '@shared/types/fire
 import type {AsyncResult} from '@shared/types/results.types';
 
 export class ServerFirecrawlService {
-  constructor(private readonly firecrawlApp: FirecrawlApp) {}
+  private readonly firecrawlApp: FirecrawlApp;
+
+  constructor(args: {readonly firecrawlApp: FirecrawlApp}) {
+    this.firecrawlApp = args.firecrawlApp;
+  }
 
   /**
    * Firecrawl is used for:


### PR DESCRIPTION
Matches some of what I did in #305 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized Firebase service initialization and usage across server and script modules, improving maintainability and consistency.
  - Updated constructors of various server-side services to accept a shared Firebase service instance instead of specialized collection services.
  - Simplified service initialization and reduced repetitive code for Firestore and Storage access.
  - Renamed internal variables in multiple client services for clearer and more consistent naming.

- **Chores**
  - Removed unused imports and streamlined service setup logic for better code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->