### PR TITLE
Splitting up `feedItems.types.ts` even more

### DIFF
--- a/packages/functions/src/reqHandlers/handleFeedItemImport.ts
+++ b/packages/functions/src/reqHandlers/handleFeedItemImport.ts
@@ -1,7 +1,7 @@
 import {prefixErrorResult} from '@shared/lib/errorUtils.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
 
-import {FeedItemImportStatus} from '@shared/types/feedItems.types';
+import {FeedItemImportStatus} from '@shared/types/feedItemImportStates';
 import type {FeedItem} from '@shared/types/feedItems.types';
 import type {AsyncResult, ErrorResult} from '@shared/types/results.types';
 

--- a/packages/pwa/src/components/feedItems/FeedItemActions.tsx
+++ b/packages/pwa/src/components/feedItems/FeedItemActions.tsx
@@ -4,8 +4,8 @@ import {useCallback} from 'react';
 import {SharedFeedItemHelpers} from '@shared/lib/feedItems.shared';
 import {makeSuccessResult} from '@shared/lib/results.shared';
 
+import {FeedItemImportStatus} from '@shared/types/feedItemImportStates';
 import type {FeedItem} from '@shared/types/feedItems.types';
-import {FeedItemImportStatus} from '@shared/types/feedItems.types';
 import type {IconName} from '@shared/types/icons.types';
 import type {AsyncResult} from '@shared/types/results.types';
 import type {KeyboardShortcutId} from '@shared/types/shortcuts.types';

--- a/packages/pwa/src/components/feedItems/FeedItemImportStatusBadge.tsx
+++ b/packages/pwa/src/components/feedItems/FeedItemImportStatusBadge.tsx
@@ -2,7 +2,8 @@ import type React from 'react';
 
 import {assertNever} from '@shared/lib/utils.shared';
 
-import {FeedItemImportStatus, type FeedItemImportState} from '@shared/types/feedItems.types';
+import type {FeedItemImportState} from '@shared/types/feedItemImportStates';
+import {FeedItemImportStatus} from '@shared/types/feedItemImportStates';
 
 import {Badge} from '@src/components/atoms/Badge';
 

--- a/packages/pwa/src/components/feedItems/ImportingFeedItem.tsx
+++ b/packages/pwa/src/components/feedItems/ImportingFeedItem.tsx
@@ -5,8 +5,8 @@ import {logger} from '@shared/services/logger.shared';
 import {SharedFeedItemHelpers} from '@shared/lib/feedItems.shared';
 import {assertNever} from '@shared/lib/utils.shared';
 
+import {FeedItemImportStatus} from '@shared/types/feedItemImportStates';
 import type {FeedItem} from '@shared/types/feedItems.types';
-import {FeedItemImportStatus} from '@shared/types/feedItems.types';
 
 import {P} from '@src/components/atoms/Text';
 

--- a/packages/shared/src/lib/eventLog.shared.ts
+++ b/packages/shared/src/lib/eventLog.shared.ts
@@ -16,7 +16,7 @@ import type {
 } from '@shared/types/eventLog.types';
 import {EventType} from '@shared/types/eventLog.types';
 import type {ExperimentId, ExperimentType} from '@shared/types/experiments.types';
-import type {FeedItemActionType} from '@shared/types/feedItems.types';
+import type {FeedItemActionType} from '@shared/types/feedItemActions.types';
 import type {FeedType} from '@shared/types/feeds.types';
 import type {
   AccountId,

--- a/packages/shared/src/lib/feedItems.shared.ts
+++ b/packages/shared/src/lib/feedItems.shared.ts
@@ -2,14 +2,14 @@ import {makeErrorResult, makeSuccessResult} from '@shared/lib/results.shared';
 import {parseUrl} from '@shared/lib/urls.shared';
 import {assertNever, makeUuid} from '@shared/lib/utils.shared';
 
+import type {FeedItemAction} from '@shared/types/feedItemActions.types';
+import {FeedItemActionType} from '@shared/types/feedItemActions.types';
 import {FeedItemContentType} from '@shared/types/feedItemContent.types';
 import type {FeedItemContent} from '@shared/types/feedItemContent.types';
-import {
-  FeedItemActionType,
-  FeedItemImportStatus,
-  TriageStatus,
-} from '@shared/types/feedItems.types';
-import type {FeedItem, FeedItemAction, NewFeedItemImportState} from '@shared/types/feedItems.types';
+import {FeedItemImportStatus} from '@shared/types/feedItemImportStates';
+import type {NewFeedItemImportState} from '@shared/types/feedItemImportStates';
+import type {FeedItem} from '@shared/types/feedItems.types';
+import {TriageStatus} from '@shared/types/feedItems.types';
 import type {Feed} from '@shared/types/feeds.types';
 import {FeedType} from '@shared/types/feeds.types';
 import {IconName} from '@shared/types/icons.types';

--- a/packages/shared/src/parsers/accounts.parser.ts
+++ b/packages/shared/src/parsers/accounts.parser.ts
@@ -6,7 +6,8 @@ import type {Account} from '@shared/types/accounts.types';
 import type {AccountId} from '@shared/types/ids.types';
 import type {Result} from '@shared/types/results.types';
 
-import {AccountIdSchema, AccountSchema} from '@shared/schemas/accounts.schema';
+import {AccountSchema} from '@shared/schemas/accounts.schema';
+import {AccountIdSchema} from '@shared/schemas/ids.schema';
 import {fromStorageAccount} from '@shared/storage/accounts.storage';
 
 /**

--- a/packages/shared/src/parsers/eventLog.parser.ts
+++ b/packages/shared/src/parsers/eventLog.parser.ts
@@ -6,7 +6,8 @@ import type {EventLogItem} from '@shared/types/eventLog.types';
 import type {EventLogItemId} from '@shared/types/ids.types';
 import type {Result} from '@shared/types/results.types';
 
-import {EventLogItemIdSchema, EventLogItemSchema} from '@shared/schemas/eventLog.schema';
+import {EventLogItemSchema} from '@shared/schemas/eventLog.schema';
+import {EventLogItemIdSchema} from '@shared/schemas/ids.schema';
 import {fromStorageEventLogItem} from '@shared/storage/eventLog.storage';
 
 /**

--- a/packages/shared/src/parsers/feedItems.parser.ts
+++ b/packages/shared/src/parsers/feedItems.parser.ts
@@ -6,7 +6,8 @@ import type {FeedItem} from '@shared/types/feedItems.types';
 import type {FeedItemId} from '@shared/types/ids.types';
 import type {Result} from '@shared/types/results.types';
 
-import {FeedItemIdSchema, FeedItemSchema} from '@shared/schemas/feedItems.schema';
+import {FeedItemSchema} from '@shared/schemas/feedItems.schema';
+import {FeedItemIdSchema} from '@shared/schemas/ids.schema';
 import {fromStorageFeedItem} from '@shared/storage/feedItems.storage';
 
 /**

--- a/packages/shared/src/parsers/feedSubscriptions.parser.ts
+++ b/packages/shared/src/parsers/feedSubscriptions.parser.ts
@@ -10,10 +10,10 @@ import type {FeedSubscriptionId} from '@shared/types/ids.types';
 import type {Result} from '@shared/types/results.types';
 
 import {
-  FeedSubscriptionIdSchema,
   FeedSubscriptionLifecycleSchema,
   FeedSubscriptionSchema,
 } from '@shared/schemas/feedSubscriptions.schema';
+import {FeedSubscriptionIdSchema} from '@shared/schemas/ids.schema';
 import {fromStorageFeedSubscription} from '@shared/storage/feedSubscriptions.storage';
 
 /**

--- a/packages/shared/src/parsers/tags.parser.ts
+++ b/packages/shared/src/parsers/tags.parser.ts
@@ -7,12 +7,8 @@ import type {Result} from '@shared/types/results.types';
 import type {SystemTag, SystemTagId, UserTag} from '@shared/types/tags.types';
 import {TagType} from '@shared/types/tags.types';
 
-import {
-  SystemTagIdSchema,
-  SystemTagSchema,
-  UserTagIdSchema,
-  UserTagSchema,
-} from '@shared/schemas/tags.schema';
+import {UserTagIdSchema} from '@shared/schemas/ids.schema';
+import {SystemTagIdSchema, SystemTagSchema, UserTagSchema} from '@shared/schemas/tags.schema';
 
 /**
  * Parses a {@link UserTagId} from a plain string. Returns an `ErrorResult` if the string is not

--- a/packages/shared/src/schemas/accountSettings.schema.ts
+++ b/packages/shared/src/schemas/accountSettings.schema.ts
@@ -1,6 +1,6 @@
 import type {z} from 'zod/v4';
 
-import {AccountIdSchema} from '@shared/schemas/accounts.schema';
+import {AccountIdSchema} from '@shared/schemas/ids.schema';
 import {ThemePreferenceSchema} from '@shared/schemas/theme.schema';
 import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
 

--- a/packages/shared/src/schemas/accounts.schema.ts
+++ b/packages/shared/src/schemas/accounts.schema.ts
@@ -1,9 +1,8 @@
 import {z} from 'zod/v4';
 
 import {EmailAddressSchema} from '@shared/schemas/emails.schema';
+import {AccountIdSchema} from '@shared/schemas/ids.schema';
 import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
-
-export const AccountIdSchema = z.string().min(1).max(128);
 
 export const AccountSchema = BaseStoreItemSchema.extend({
   accountId: AccountIdSchema,

--- a/packages/shared/src/schemas/actors.schema.ts
+++ b/packages/shared/src/schemas/actors.schema.ts
@@ -2,7 +2,7 @@ import {z} from 'zod/v4';
 
 import {ActorType} from '@shared/types/actors.types';
 
-import {AccountIdSchema} from '@shared/schemas/accounts.schema';
+import {AccountIdSchema} from '@shared/schemas/ids.schema';
 
 const AccountActorSchema = z.object({
   actorType: z.literal(ActorType.Account),

--- a/packages/shared/src/schemas/eventLog.schema.ts
+++ b/packages/shared/src/schemas/eventLog.schema.ts
@@ -2,18 +2,19 @@ import {z} from 'zod/v4';
 
 import {Environment} from '@shared/types/environment.types';
 import {EventType} from '@shared/types/eventLog.types';
-import {FeedItemActionType} from '@shared/types/feedItems.types';
+import {FeedItemActionType} from '@shared/types/feedItemActions.types';
 import {FeedType} from '@shared/types/feeds.types';
 
-import {AccountIdSchema} from '@shared/schemas/accounts.schema';
 import {ActorSchema} from '@shared/schemas/actors.schema';
 import {ExperimentIdSchema, ExperimentTypeSchema} from '@shared/schemas/experiments.schema';
-import {FeedItemIdSchema} from '@shared/schemas/feedItems.schema';
-import {FeedSubscriptionIdSchema} from '@shared/schemas/feedSubscriptions.schema';
+import {
+  AccountIdSchema,
+  EventLogItemIdSchema,
+  FeedItemIdSchema,
+  FeedSubscriptionIdSchema,
+} from '@shared/schemas/ids.schema';
 import {ThemePreferenceSchema} from '@shared/schemas/theme.schema';
 import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
-
-export const EventLogItemIdSchema = z.uuid();
 
 const BaseEventLogItemDataSchema = z.object({
   eventType: z.enum(EventType),

--- a/packages/shared/src/schemas/experiments.schema.ts
+++ b/packages/shared/src/schemas/experiments.schema.ts
@@ -2,9 +2,9 @@ import {z} from 'zod/v4';
 
 import {ExperimentId, ExperimentType, ExperimentVisibility} from '@shared/types/experiments.types';
 
-import {AccountIdSchema} from '@shared/schemas/accounts.schema';
 import {EnvironmentSchema} from '@shared/schemas/environments.schema';
 import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
+import {AccountIdSchema} from '@shared/schemas/ids.schema';
 
 export const ExperimentIdSchema = z.enum(ExperimentId);
 export const ExperimentTypeSchema = z.enum(ExperimentType);

--- a/packages/shared/src/schemas/feedItemImportStates.schema.ts
+++ b/packages/shared/src/schemas/feedItemImportStates.schema.ts
@@ -1,0 +1,45 @@
+import {z} from 'zod/v4';
+
+import {FeedItemImportStatus} from '@shared/types/feedItemImportStates';
+
+import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
+
+const NewFeedItemImportStateSchema = z.object({
+  status: z.literal(FeedItemImportStatus.New),
+  shouldFetch: z.literal(true),
+  lastSuccessfulImportTime: z.null(),
+  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
+});
+
+const ProcessingFeedItemImportStateSchema = z.object({
+  status: z.literal(FeedItemImportStatus.Processing),
+  shouldFetch: z.literal(false),
+  importStartedTime: FirestoreTimestampSchema.or(z.date()),
+  lastSuccessfulImportTime: FirestoreTimestampSchema.or(z.date()).or(z.null()),
+  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
+});
+
+const FailedFeedItemImportStateSchema = z.object({
+  status: z.literal(FeedItemImportStatus.Failed),
+  shouldFetch: z.boolean(),
+  errorMessage: z.string(),
+  importFailedTime: FirestoreTimestampSchema.or(z.date()),
+  lastSuccessfulImportTime: FirestoreTimestampSchema.or(z.date()).or(z.null()),
+  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
+});
+
+const CompletedFeedItemImportStateSchema = z.object({
+  status: z.literal(FeedItemImportStatus.Completed),
+  shouldFetch: z.boolean(),
+  lastSuccessfulImportTime: FirestoreTimestampSchema.or(z.date()),
+  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
+});
+
+export const FeedItemImportStateSchema = z.discriminatedUnion('status', [
+  NewFeedItemImportStateSchema,
+  ProcessingFeedItemImportStateSchema,
+  FailedFeedItemImportStateSchema,
+  CompletedFeedItemImportStateSchema,
+]);
+
+export type FeedItemImportStateFromStorage = z.infer<typeof FeedItemImportStateSchema>;

--- a/packages/shared/src/schemas/feedItems.schema.ts
+++ b/packages/shared/src/schemas/feedItems.schema.ts
@@ -1,9 +1,8 @@
 import {z} from 'zod/v4';
 
 import {FeedItemContentType} from '@shared/types/feedItemContent.types';
-import {FeedItemImportStatus, TriageStatus} from '@shared/types/feedItems.types';
+import {TriageStatus} from '@shared/types/feedItems.types';
 
-import {AccountIdSchema} from '@shared/schemas/accounts.schema';
 import {
   ArticleFeedItemContentSchema,
   IntervalFeedItemContentSchema,
@@ -13,58 +12,11 @@ import {
   XkcdFeedItemContentSchema,
   YouTubeFeedItemContentSchema,
 } from '@shared/schemas/feedItemContent.schema';
+import {FeedItemImportStateSchema} from '@shared/schemas/feedItemImportStates.schema';
 import {FeedSchema} from '@shared/schemas/feeds.schema';
-import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
+import {AccountIdSchema, FeedItemIdSchema} from '@shared/schemas/ids.schema';
 import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
 
-export const FeedItemIdSchema = z.uuid();
-
-//////////////////////////////
-//  FEED ITEM IMPORT STATE  //
-//////////////////////////////
-const NewFeedItemImportStateSchema = z.object({
-  status: z.literal(FeedItemImportStatus.New),
-  shouldFetch: z.literal(true),
-  lastSuccessfulImportTime: z.null(),
-  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
-});
-
-const ProcessingFeedItemImportStateSchema = z.object({
-  status: z.literal(FeedItemImportStatus.Processing),
-  shouldFetch: z.literal(false),
-  importStartedTime: FirestoreTimestampSchema.or(z.date()),
-  lastSuccessfulImportTime: FirestoreTimestampSchema.or(z.date()).or(z.null()),
-  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
-});
-
-const FailedFeedItemImportStateSchema = z.object({
-  status: z.literal(FeedItemImportStatus.Failed),
-  shouldFetch: z.boolean(),
-  errorMessage: z.string(),
-  importFailedTime: FirestoreTimestampSchema.or(z.date()),
-  lastSuccessfulImportTime: FirestoreTimestampSchema.or(z.date()).or(z.null()),
-  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
-});
-
-const CompletedFeedItemImportStateSchema = z.object({
-  status: z.literal(FeedItemImportStatus.Completed),
-  shouldFetch: z.boolean(),
-  lastSuccessfulImportTime: FirestoreTimestampSchema.or(z.date()),
-  lastImportRequestedTime: FirestoreTimestampSchema.or(z.date()),
-});
-
-const FeedItemImportStateSchema = z.discriminatedUnion('status', [
-  NewFeedItemImportStateSchema,
-  ProcessingFeedItemImportStateSchema,
-  FailedFeedItemImportStateSchema,
-  CompletedFeedItemImportStateSchema,
-]);
-
-export type FeedItemImportStateFromStorage = z.infer<typeof FeedItemImportStateSchema>;
-
-/////////////////
-//  FEED ITEM  //
-/////////////////
 const BaseFeedItemSchema = BaseStoreItemSchema.extend({
   origin: FeedSchema,
   feedItemId: FeedItemIdSchema,

--- a/packages/shared/src/schemas/feedSubscriptions.schema.ts
+++ b/packages/shared/src/schemas/feedSubscriptions.schema.ts
@@ -3,12 +3,10 @@ import {z} from 'zod/v4';
 import {FEED_TYPES_WITH_SUBSCRIPTIONS, FeedType} from '@shared/types/feeds.types';
 import {FeedSubscriptionActivityStatus} from '@shared/types/feedSubscriptions.types';
 
-import {AccountIdSchema} from '@shared/schemas/accounts.schema';
 import {DeliveryScheduleSchema} from '@shared/schemas/deliverySchedules.schema';
 import {FirestoreTimestampSchema} from '@shared/schemas/firebase.schema';
+import {AccountIdSchema, FeedSubscriptionIdSchema} from '@shared/schemas/ids.schema';
 import {YouTubeChannelIdSchema} from '@shared/schemas/youtube.schema';
-
-export const FeedSubscriptionIdSchema = z.uuid();
 
 const FeedSubscriptionActivityStatusSchema = z.enum(FeedSubscriptionActivityStatus);
 

--- a/packages/shared/src/schemas/feeds.schema.ts
+++ b/packages/shared/src/schemas/feeds.schema.ts
@@ -2,7 +2,7 @@ import {z} from 'zod/v4';
 
 import {FeedType} from '@shared/types/feeds.types';
 
-import {FeedSubscriptionIdSchema} from '@shared/schemas/feedSubscriptions.schema';
+import {FeedSubscriptionIdSchema} from '@shared/schemas/ids.schema';
 
 const BaseFeedSchema = z.object({
   feedType: z.enum(FeedType),

--- a/packages/shared/src/schemas/ids.schema.ts
+++ b/packages/shared/src/schemas/ids.schema.ts
@@ -1,0 +1,11 @@
+import z from 'zod/v4';
+
+export const AccountIdSchema = z.string().min(1).max(128);
+
+export const FeedItemIdSchema = z.uuid();
+
+export const FeedSubscriptionIdSchema = z.uuid();
+
+export const UserTagIdSchema = z.uuid();
+
+export const EventLogItemIdSchema = z.uuid();

--- a/packages/shared/src/schemas/tags.schema.ts
+++ b/packages/shared/src/schemas/tags.schema.ts
@@ -2,9 +2,8 @@ import {z} from 'zod/v4';
 
 import {SystemTagId} from '@shared/types/tags.types';
 
+import {UserTagIdSchema} from '@shared/schemas/ids.schema';
 import {BaseStoreItemSchema} from '@shared/schemas/utils.schema';
-
-export const UserTagIdSchema = z.uuid();
 
 export const SystemTagIdSchema = z.enum(SystemTagId);
 

--- a/packages/shared/src/storage/feedItems.storage.ts
+++ b/packages/shared/src/storage/feedItems.storage.ts
@@ -8,10 +8,11 @@ import {parseFeedItemId} from '@shared/parsers/feedItems.parser';
 import {parseFeed} from '@shared/parsers/feeds.parser';
 
 import {FeedItemContentType} from '@shared/types/feedItemContent.types';
+import type {FeedItemImportState} from '@shared/types/feedItemImportStates';
+import {FeedItemImportStatus} from '@shared/types/feedItemImportStates';
 import type {
   ArticleFeedItem,
   FeedItem,
-  FeedItemImportState,
   IntervalFeedItem,
   TriageStatus,
   TweetFeedItem,
@@ -20,15 +21,14 @@ import type {
   XkcdFeedItem,
   YouTubeFeedItem,
 } from '@shared/types/feedItems.types';
-import {FeedItemImportStatus} from '@shared/types/feedItems.types';
 import type {Feed} from '@shared/types/feeds.types';
 import type {AccountId, FeedItemId} from '@shared/types/ids.types';
 import type {Result} from '@shared/types/results.types';
 
+import type {FeedItemImportStateFromStorage} from '@shared/schemas/feedItemImportStates.schema';
 import type {
   ArticleFeedItemFromStorage,
   FeedItemFromStorage,
-  FeedItemImportStateFromStorage,
   IntervalFeedItemFromStorage,
   TweetFeedItemFromStorage,
   VideoFeedItemFromStorage,

--- a/packages/shared/src/types/eventLog.types.ts
+++ b/packages/shared/src/types/eventLog.types.ts
@@ -1,7 +1,7 @@
 import type {Actor} from '@shared/types/actors.types';
 import type {Environment} from '@shared/types/environment.types';
 import type {ExperimentId, ExperimentType} from '@shared/types/experiments.types';
-import type {FeedItemActionType} from '@shared/types/feedItems.types';
+import type {FeedItemActionType} from '@shared/types/feedItemActions.types';
 import type {FeedType} from '@shared/types/feeds.types';
 import type {
   AccountId,

--- a/packages/shared/src/types/feedItemActions.types.ts
+++ b/packages/shared/src/types/feedItemActions.types.ts
@@ -1,0 +1,24 @@
+import type {IconName} from '@shared/types/icons.types';
+import type {KeyboardShortcutId} from '@shared/types/shortcuts.types';
+
+export enum FeedItemActionType {
+  Cancel = 'CANCEL',
+  MarkDone = 'MARK_DONE',
+  MarkUndone = 'MARK_UNDONE',
+  MarkRead = 'MARK_READ',
+  MarkUnread = 'MARK_UNREAD',
+  Save = 'SAVE',
+  Unsave = 'UNSAVE',
+  Star = 'STAR',
+  Unstar = 'UNSTAR',
+  RetryImport = 'RETRY_IMPORT',
+  Undo = 'UNDO',
+}
+
+export interface FeedItemAction {
+  readonly actionType: FeedItemActionType;
+  // TODO: Should this have `feedId` on it? Should it be optional?
+  readonly text: string;
+  readonly icon: IconName;
+  readonly shortcutId?: KeyboardShortcutId;
+}

--- a/packages/shared/src/types/feedItemImportStates.ts
+++ b/packages/shared/src/types/feedItemImportStates.ts
@@ -1,0 +1,50 @@
+export enum FeedItemImportStatus {
+  /** Created but not yet processed. */
+  New = 'NEW',
+  /** Currently being processed. */
+  Processing = 'PROCESSING',
+  /** Errored while processing. May have partially imported data. */
+  Failed = 'FAILED',
+  /** Successfully imported all data. */
+  Completed = 'COMPLETED',
+}
+
+interface BaseFeedItemImportState {
+  readonly status: FeedItemImportStatus;
+  readonly shouldFetch: boolean;
+  readonly lastImportRequestedTime: Date;
+  readonly lastSuccessfulImportTime: Date | null;
+}
+
+export interface NewFeedItemImportState extends BaseFeedItemImportState {
+  readonly status: FeedItemImportStatus.New;
+  readonly shouldFetch: true;
+  readonly lastSuccessfulImportTime: null;
+}
+
+interface ProcessingFeedItemImportState extends BaseFeedItemImportState {
+  readonly status: FeedItemImportStatus.Processing;
+  readonly shouldFetch: false;
+  readonly importStartedTime: Date;
+  readonly lastSuccessfulImportTime: Date | null;
+}
+
+interface FailedFeedItemImportState extends BaseFeedItemImportState {
+  readonly status: FeedItemImportStatus.Failed;
+  readonly shouldFetch: boolean;
+  readonly errorMessage: string;
+  readonly importFailedTime: Date;
+  readonly lastSuccessfulImportTime: Date | null;
+}
+
+interface CompletedFeedItemImportState extends BaseFeedItemImportState {
+  readonly status: FeedItemImportStatus.Completed;
+  readonly shouldFetch: boolean;
+  readonly lastSuccessfulImportTime: Date;
+}
+
+export type FeedItemImportState =
+  | NewFeedItemImportState
+  | ProcessingFeedItemImportState
+  | FailedFeedItemImportState
+  | CompletedFeedItemImportState;

--- a/packages/shared/src/types/feedItems.types.ts
+++ b/packages/shared/src/types/feedItems.types.ts
@@ -9,10 +9,9 @@ import type {
   XkcdFeedItemContent,
   YouTubeFeedItemContent,
 } from '@shared/types/feedItemContent.types';
+import type {FeedItemImportState} from '@shared/types/feedItemImportStates';
 import type {Feed} from '@shared/types/feeds.types';
-import type {IconName} from '@shared/types/icons.types';
 import type {AccountId, FeedItemId} from '@shared/types/ids.types';
-import type {KeyboardShortcutId} from '@shared/types/shortcuts.types';
 import type {TagId} from '@shared/types/tags.types';
 import type {BaseStoreItem} from '@shared/types/utils.types';
 
@@ -100,77 +99,4 @@ export enum TriageStatus {
   Saved = 'SAVED',
   Done = 'DONE',
   Trashed = 'TRASHED',
-}
-
-export enum FeedItemImportStatus {
-  /** Created but not yet processed. */
-  New = 'NEW',
-  /** Currently being processed. */
-  Processing = 'PROCESSING',
-  /** Errored while processing. May have partially imported data. */
-  Failed = 'FAILED',
-  /** Successfully imported all data. */
-  Completed = 'COMPLETED',
-}
-
-interface BaseFeedItemImportState {
-  readonly status: FeedItemImportStatus;
-  readonly shouldFetch: boolean;
-  readonly lastImportRequestedTime: Date;
-  readonly lastSuccessfulImportTime: Date | null;
-}
-
-export interface NewFeedItemImportState extends BaseFeedItemImportState {
-  readonly status: FeedItemImportStatus.New;
-  readonly shouldFetch: true;
-  readonly lastSuccessfulImportTime: null;
-}
-
-interface ProcessingFeedItemImportState extends BaseFeedItemImportState {
-  readonly status: FeedItemImportStatus.Processing;
-  readonly shouldFetch: false;
-  readonly importStartedTime: Date;
-  readonly lastSuccessfulImportTime: Date | null;
-}
-
-interface FailedFeedItemImportState extends BaseFeedItemImportState {
-  readonly status: FeedItemImportStatus.Failed;
-  readonly shouldFetch: boolean;
-  readonly errorMessage: string;
-  readonly importFailedTime: Date;
-  readonly lastSuccessfulImportTime: Date | null;
-}
-
-interface CompletedFeedItemImportState extends BaseFeedItemImportState {
-  readonly status: FeedItemImportStatus.Completed;
-  readonly shouldFetch: boolean;
-  readonly lastSuccessfulImportTime: Date;
-}
-
-export type FeedItemImportState =
-  | NewFeedItemImportState
-  | ProcessingFeedItemImportState
-  | FailedFeedItemImportState
-  | CompletedFeedItemImportState;
-
-export enum FeedItemActionType {
-  Cancel = 'CANCEL',
-  MarkDone = 'MARK_DONE',
-  MarkUndone = 'MARK_UNDONE',
-  MarkRead = 'MARK_READ',
-  MarkUnread = 'MARK_UNREAD',
-  Save = 'SAVE',
-  Unsave = 'UNSAVE',
-  Star = 'STAR',
-  Unstar = 'UNSTAR',
-  RetryImport = 'RETRY_IMPORT',
-  Undo = 'UNDO',
-}
-
-export interface FeedItemAction {
-  readonly actionType: FeedItemActionType;
-  // TODO: Should this have `feedId` on it? Should it be optional?
-  readonly text: string;
-  readonly icon: IconName;
-  readonly shortcutId?: KeyboardShortcutId;
 }

--- a/packages/sharedClient/src/services/eventLog.client.ts
+++ b/packages/sharedClient/src/services/eventLog.client.ts
@@ -23,7 +23,7 @@ import {parseEventLogItem, parseEventLogItemId} from '@shared/parsers/eventLog.p
 import type {Environment} from '@shared/types/environment.types';
 import type {EventLogItem, EventLogItemData} from '@shared/types/eventLog.types';
 import type {ExperimentId, ExperimentType} from '@shared/types/experiments.types';
-import type {FeedItemActionType} from '@shared/types/feedItems.types';
+import type {FeedItemActionType} from '@shared/types/feedItemActions.types';
 import type {FeedType} from '@shared/types/feeds.types';
 import type {
   AccountId,

--- a/packages/sharedClient/src/services/feedItems.client.ts
+++ b/packages/sharedClient/src/services/feedItems.client.ts
@@ -16,8 +16,9 @@ import {Views} from '@shared/lib/views.shared';
 
 import {parseFeedItem, parseFeedItemId} from '@shared/parsers/feedItems.parser';
 
+import {FeedItemActionType} from '@shared/types/feedItemActions.types';
 import type {FeedItem} from '@shared/types/feedItems.types';
-import {FeedItemActionType, TriageStatus} from '@shared/types/feedItems.types';
+import {TriageStatus} from '@shared/types/feedItems.types';
 import type {Feed} from '@shared/types/feeds.types';
 import type {AccountId, FeedItemId} from '@shared/types/ids.types';
 import {fromQueryFilterOp} from '@shared/types/query.types';

--- a/packages/sharedServer/src/services/feedItems.server.ts
+++ b/packages/sharedServer/src/services/feedItems.server.ts
@@ -22,7 +22,8 @@ import type {
   YouTubeFeedItemContent,
 } from '@shared/types/feedItemContent.types';
 import {FeedItemContentType} from '@shared/types/feedItemContent.types';
-import type {FeedItem, FeedItemImportState, IntervalFeedItem} from '@shared/types/feedItems.types';
+import type {FeedItemImportState} from '@shared/types/feedItemImportStates';
+import type {FeedItem, IntervalFeedItem} from '@shared/types/feedItems.types';
 import type {Feed} from '@shared/types/feeds.types';
 import type {IntervalFeedSubscription} from '@shared/types/feedSubscriptions.types';
 import type {AccountId, FeedItemId} from '@shared/types/ids.types';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized and modularized schema and type definitions for feed item import states, feed item actions, and various ID types.
  - Updated import paths throughout the codebase to use new dedicated modules for import states, actions, and ID schemas.
  - Removed redundant or duplicated type and schema definitions, improving code organization and maintainability.

- **New Features**
  - Introduced new modules for feed item import state schemas, feed item action types, and standardized ID validation schemas.

- **Chores**
  - No user-facing changes in functionality; internal structure and code organization improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->